### PR TITLE
feat: litematic block-state mapping, easy-place orientation, 26.20.7

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -5,7 +5,7 @@
 当前基线：
 
 - Minecraft Bedrock Windows：`1.26.20.04`
-- LeviLamina：`26.20.0`，目标类型 `client`
+- LeviLamina：`26.20.7`，目标类型 `client`
 - 架构：Windows x64
 - 图形接口：Minecraft D3D12 + LHolo D3D11On12 + Dear ImGui DX11 后端
 - 模组名称、DLL、目录和内部命名空间：`LHolo` / `LHolo.dll` / `mods/LHolo` / `lholo`
@@ -526,7 +526,7 @@ WndProc 收到首次 `WM_KEYDOWN + VK_F11`，在消息交回 Minecraft 前：
 mods/LHolo/config/config.json
 ```
 
-当前配置版本：`6`。
+当前配置版本：`7`。
 
 正式持久化字段：
 
@@ -538,6 +538,7 @@ mods/LHolo/config/config.json
 - `correctionOutlineOpacity`
 - `structureBoundsEnabled`
 - `easyPlaceEnabled`
+- `easyPlaceManual`
 - `rangePlaceEnabled`
 - `placementRadius`
 - HUD 开关、各项显示开关（含 `hudShowBlockEntity` 方块实体名称）、位置
@@ -563,7 +564,7 @@ mods/LHolo/config/config.json
 
 - Visual Studio 2022 C++ 工具链
 - xmake
-- LeviLamina 26.20.0 client
+- LeviLamina 26.20.7 client
 - levibuildscript
 - Dear ImGui 1.91.9，Win32 + DX11，静态
 - MinHook

--- a/src/place/PlaceHelper.cpp
+++ b/src/place/PlaceHelper.cpp
@@ -31,6 +31,7 @@
 #include "mc/network/PacketSender.h"
 #include "mc/network/packet/InventoryTransactionPacket.h"
 #include "mc/world/Facing.h"
+#include "mc/world/gamemode/GameMode.h"
 #include "mc/world/ContainerID.h"
 #include "mc/world/actor/player/Inventory.h"
 #include "mc/world/actor/player/Player.h"
@@ -46,6 +47,11 @@
 #include "mc/world/level/Tick.h"
 #include "mc/world/level/block/Block.h"
 #include "mc/world/level/block/actor/BlockActorType.h"
+#include "mc/deps/nbt/ByteTag.h"
+#include "mc/deps/nbt/CompoundTag.h"
+#include "mc/deps/nbt/IntTag.h"
+#include "mc/deps/nbt/StringTag.h"
+#include "mc/deps/nbt/Tag.h"
 
 #include <Windows.h>
 
@@ -53,8 +59,12 @@
 #include <atomic>
 #include <cmath>
 #include <cstdint>
+#include <iterator>
 #include <limits>
+#include <mutex>
 #include <optional>
+#include <string_view>
+#include <unordered_map>
 
 namespace lholo::place {
 namespace {
@@ -74,16 +84,63 @@ constexpr std::uint64_t kMinSendIntervalMs = 40;
 // Backoff for a rejected inventory swap. Without it a failed swap retries every
 // tick and spams the server.
 constexpr std::uint64_t kSwapRetryMs = 50;
+// Manual-mode typematic repeat: after the first block on press, holding pauses
+// for kManualInitialDelayMs and then auto-repeats every kManualRepeatIntervalMs
+// (like keyboard key-repeat), so a tap places one and a hold streams at a steady
+// rate.
+constexpr std::uint64_t kManualInitialDelayMs   = 150;
+constexpr std::uint64_t kManualRepeatIntervalMs = 120;
+// A pending first-block request expires if it cannot be fulfilled this long
+// after the press, so a stale click never places a block later.
+constexpr std::uint64_t kManualRequestTimeoutMs = 400;
 
 std::atomic_bool gEnabled{false};
 std::atomic_bool gRangeEnabled{false};
+// Manual mode: hold the right mouse button to place, instead of auto-placing.
+std::atomic_bool gManualMode{false};
+// Manual-mode press/hold tracking (typematic repeat). gManualHeld spans the
+// press (startBuildBlock) to the release (stopBuildBlock); the timestamps drive
+// the repeat rate.
+std::atomic_bool     gManualHeld{false};
+// Pending first block of a press; set on press and kept until placed so a quick
+// tap (released before the next game tick) still places one block.
+std::atomic_bool     gManualPlaceRequested{false};
+std::atomic_uint64_t gManualPressAt{0};
+std::atomic_uint64_t gLastManualPlaceAt{0};
 // Scan radius for range placement (blocks). Actual placement still respects
 // the player's reach.
 std::atomic_int gPlacementRadius{4};
 std::atomic_uint64_t gNextPlaceAt{0};
-std::optional<BlockPos> gLastPlaceCell;
-std::atomic_uint64_t gLastPlaceAt{0};
 std::atomic_uint64_t gNextSwapAt{0};
+// Recently-placed cells, so a cell placed a tick ago is not targeted again
+// before the server applies it and the correction scan catches up. This is what
+// stops a slab (or any block) being placed twice into the same cell during the
+// server round-trip (the reported "slab becomes a full block"). Keyed by packed
+// world position; the value is the millisecond time the lock expires.
+std::mutex                                      gRecentMutex;
+std::unordered_map<std::int64_t, std::uint64_t> gRecentPlacements;
+
+std::int64_t packBlockPos(BlockPos const& p) {
+    return (static_cast<std::int64_t>(p.x) & 0x3FFFFFF) << 38
+         | (static_cast<std::int64_t>(p.z) & 0x3FFFFFF) << 12
+         | (static_cast<std::int64_t>(p.y) & 0xFFF);
+}
+
+bool recentlyPlaced(BlockPos const& cell, std::uint64_t now) {
+    std::lock_guard lock(gRecentMutex);
+    auto const it = gRecentPlacements.find(packBlockPos(cell));
+    return it != gRecentPlacements.end() && now < it->second;
+}
+
+void markPlaced(BlockPos const& cell, std::uint64_t now) {
+    std::lock_guard lock(gRecentMutex);
+    if (gRecentPlacements.size() > 256) {
+        for (auto it = gRecentPlacements.begin(); it != gRecentPlacements.end();) {
+            it = now >= it->second ? gRecentPlacements.erase(it) : std::next(it);
+        }
+    }
+    gRecentPlacements[packBlockPos(cell)] = now + kCellLockMs;
+}
 // Name of the block-entity block the crosshair currently points at, shown in
 // the HUD so projected chests/signs/hoppers/... can be identified.
 std::string gAimedBlockEntityName;
@@ -108,11 +165,31 @@ struct ItemFind {
     ItemStack const* item;
 };
 
-ItemFind findItemSlot(Player& player, ItemStack const& want) {
+// Blocks whose placing item has a different name than the block. ItemStack(Block)
+// does not resolve these to the right inventory item (the item was never found),
+// so the item is built from its real name instead.
+char const* placingItemName(std::string const& blockName) {
+    if (blockName == "minecraft:redstone_wire") return "minecraft:redstone";
+    if (blockName == "minecraft:unpowered_comparator" || blockName == "minecraft:powered_comparator")
+        return "minecraft:comparator";
+    if (blockName == "minecraft:unpowered_repeater" || blockName == "minecraft:powered_repeater")
+        return "minecraft:repeater";
+    if (blockName == "minecraft:unlit_redstone_torch") return "minecraft:redstone_torch";
+    return nullptr;
+}
+
+// Find an inventory slot holding the item that places `block`. Match on item +
+// aux only (ignoring block/placement data): a plain inventory comparator or
+// redstone item carries no placement state, so the stricter
+// sameItemAndAuxAndBlockData never matched a ghost that does.
+ItemFind findItemSlot(Player& player, Block const& block) {
+    char const* const itemName = placingItemName(block.getTypeName());
+    ItemStack const want = itemName ? ItemStack(std::string_view{itemName}, 1, 0, nullptr)
+                                    : ItemStack(block, 1, nullptr);
     auto& inventory = player.getInventory();
     for (int slot = 0; slot < kInventorySlots; ++slot) {
         auto const& item = inventory.getItem(slot);
-        if (item.sameItemAndAuxAndBlockData(want)) return {slot, &item};
+        if (item.sameItemAndAux(want)) return {slot, &item};
     }
     return {-1, nullptr};
 }
@@ -144,6 +221,7 @@ struct ProjectionTarget {
     BlockPos     at;
     uchar        face;
     Block const* block;
+    Vec3         clickPos{};  // Exact click point; chosen to reproduce the ghost.
 };
 
 // Which face of a cell points most along the given (unit) direction.
@@ -280,14 +358,9 @@ void placeBlock(LocalPlayer& player, ProjectionTarget const& target, int slot, I
     // hotbar items are selected directly, backpack items were swapped in.
     transaction.mSlot = slot;
     transaction.mFromPos = player.getPosition();
-    // Click point: the center of the target cell. A point on the shared face
-    // between the support and the cell sits exactly on the cell boundary, and
-    // the server's cell rounding can then land one cell toward the player.
-    transaction.mClickPos = Vec3{
-        static_cast<float>(target.cell.x) + 0.5f,
-        static_cast<float>(target.cell.y) + 0.5f,
-        static_cast<float>(target.cell.z) + 0.5f
-    };
+    // Click point chosen by the orientation search so the server reproduces the
+    // ghost's placement state (which face/half it resolves to).
+    transaction.mClickPos = target.clickPos;
     transaction.mClientPredictedResult = ItemUseInventoryTransaction::PredictedResult::Success;
     transaction.mClientCooldownState = ItemUseInventoryTransaction::ClientCooldownState::Off;
     transaction.setTargetBlock(region.getBlock(target.at));
@@ -313,6 +386,208 @@ void placeBlock(LocalPlayer& player, ProjectionTarget const& target, int slot, I
     gNextPlaceAt.store(GetTickCount64() + kMinSendIntervalMs, std::memory_order_release);
 }
 
+// Candidate click points on the face of `cell` shared with the support in
+// direction `sf`. Side faces get a low and a high point so the search can reach
+// both halves (top/bottom slabs, upside-down stairs); top/bottom faces have a
+// single natural point.
+template <class F>
+void forEachClickCandidate(BlockPos const& cell, uchar sf, F&& fn) {
+    float const cx = static_cast<float>(cell.x);
+    float const cy = static_cast<float>(cell.y);
+    float const cz = static_cast<float>(cell.z);
+    switch (static_cast<Facing::Name>(sf)) {
+    case Facing::Name::Down:  fn(Vec3{cx + 0.5f, cy + 0.0f, cz + 0.5f}); break;
+    case Facing::Name::Up:    fn(Vec3{cx + 0.5f, cy + 1.0f, cz + 0.5f}); break;
+    case Facing::Name::North: fn(Vec3{cx + 0.5f, cy + 0.25f, cz + 0.0f});
+                              fn(Vec3{cx + 0.5f, cy + 0.75f, cz + 0.0f}); break;
+    case Facing::Name::South: fn(Vec3{cx + 0.5f, cy + 0.25f, cz + 1.0f});
+                              fn(Vec3{cx + 0.5f, cy + 0.75f, cz + 1.0f}); break;
+    case Facing::Name::West:  fn(Vec3{cx + 0.0f, cy + 0.25f, cz + 0.5f});
+                              fn(Vec3{cx + 0.0f, cy + 0.75f, cz + 0.5f}); break;
+    case Facing::Name::East:  fn(Vec3{cx + 1.0f, cy + 0.25f, cz + 0.5f});
+                              fn(Vec3{cx + 1.0f, cy + 0.75f, cz + 0.5f}); break;
+    default: break;
+    }
+}
+
+// Orientation gate (easy-place "place only when the orientation is right"). Ask
+// vanilla getPlacementBlock what block WOULD result from each reachable
+// placement (support face + click point), using the player's current facing,
+// and accept the first combo that reproduces the ghost exactly. Returns false
+// when nothing reachable matches, so the caller leaves the cell for later rather
+// than placing a wrong orientation. This reproduces the game's own computation,
+// so face-mounted blocks (torches/levers/buttons) and top/bottom halves are
+// solved automatically; rotational blocks (stairs/pistons/...) pass only while
+// the player looks the right way.
+// Centre of the face of `cell` shared with the support in direction `sf`.
+Vec3 sharedFaceCenter(BlockPos const& cell, uchar sf) {
+    float const cx = static_cast<float>(cell.x);
+    float const cy = static_cast<float>(cell.y);
+    float const cz = static_cast<float>(cell.z);
+    switch (static_cast<Facing::Name>(sf)) {
+    case Facing::Name::Down:  return Vec3{cx + 0.5f, cy + 0.0f, cz + 0.5f};
+    case Facing::Name::Up:    return Vec3{cx + 0.5f, cy + 1.0f, cz + 0.5f};
+    case Facing::Name::North: return Vec3{cx + 0.5f, cy + 0.5f, cz + 0.0f};
+    case Facing::Name::South: return Vec3{cx + 0.5f, cy + 0.5f, cz + 1.0f};
+    case Facing::Name::West:  return Vec3{cx + 0.0f, cy + 0.5f, cz + 0.5f};
+    case Facing::Name::East:  return Vec3{cx + 1.0f, cy + 0.5f, cz + 0.5f};
+    default:                  return Vec3{cx + 0.5f, cy + 0.5f, cz + 0.5f};
+    }
+}
+
+// Read one serialized state of a block as a string ("" if absent).
+std::string serializedState(Block const& block, char const* key) {
+    for (auto const& [k, v] : block.getSerializationId()) {
+        if (k != "states") continue;
+        if (!v.hold<::CompoundTag>()) break;
+        for (auto const& [stateKey, stateValue] : v.get<::CompoundTag>()) {
+            if (stateKey != key) continue;
+            switch (stateValue.getId()) {
+            case ::Tag::Type::Byte:   return std::to_string(static_cast<int>(stateValue.get<::ByteTag>().data));
+            case ::Tag::Type::Int:    return std::to_string(stateValue.get<::IntTag>().data);
+            case ::Tag::Type::String: return static_cast<std::string const&>(stateValue.get<::StringTag>());
+            default:                  return {};
+            }
+        }
+        break;
+    }
+    return {};
+}
+
+// Blocks whose final state comes from neighbours (rail curves auto-connect) or
+// is purely cosmetic-after-the-fact. The placed block can never equal the ghost
+// exactly, so easy-place gates these on the block type only.
+bool isTypeOnlyGate(Block const& block) {
+    auto const& name = block.getTypeName();
+    return name == "minecraft:rail" || name == "minecraft:golden_rail"
+        || name == "minecraft:detector_rail" || name == "minecraft:activator_rail"
+        // Redstone dust connections form from neighbours, so the placed cross/dot
+        // never equals the ghost's connection state.
+        || name == "minecraft:redstone_wire";
+}
+
+// The block's single facing value (prefixed by which state carries it, so a
+// predicted/ghost comparison uses the same one). Empty if the block has no
+// facing state.
+std::string facingValue(Block const& block) {
+    std::string v = serializedState(block, "facing_direction");
+    if (!v.empty()) return "fd:" + v;
+    v = serializedState(block, "minecraft:cardinal_direction");
+    if (!v.empty()) return "cd:" + v;
+    v = serializedState(block, "minecraft:facing_direction");
+    if (!v.empty()) return "mf:" + v;
+    return {};
+}
+
+// Blocks whose only relevant orientation is a single facing (no top/bottom half,
+// hinge, or stair shape): dispensers, droppers, observers, pistons, comparators,
+// repeaters, chests, furnaces, ... They gate on facing alone; other states
+// (triggered_bit, subtract mode, delay, lit) are set or derived after placement,
+// so an exact match would fail. Detected from the block's own states.
+bool isFacingGate(Block const& block) {
+    bool hasFacing = false;
+    for (auto const& [k, v] : block.getSerializationId()) {
+        if (k != "states") continue;
+        if (!v.hold<::CompoundTag>()) break;
+        for (auto const& [stateKey, stateValue] : v.get<::CompoundTag>()) {
+            if (stateKey == "facing_direction" || stateKey == "minecraft:cardinal_direction"
+                || stateKey == "minecraft:facing_direction") {
+                hasFacing = true;
+            } else if (stateKey == "upside_down_bit" || stateKey == "upper_block_bit"
+                || stateKey == "minecraft:vertical_half" || stateKey == "top_slot_bit"
+                || stateKey == "open_bit" || stateKey == "door_hinge_bit"
+                || stateKey == "weirdo_direction") {
+                return false;  // has half/hinge/stair shape -> needs the exact gate
+            }
+        }
+        break;
+    }
+    return hasFacing;
+}
+
+bool resolveOrientedPlacement(
+    LocalPlayer& player, BlockSource& region, BlockPos const& cell,
+    Block const& ghost, int itemAux, bool requireExact, ProjectionTarget& out
+) {
+    bool const typeOnly = isTypeOnlyGate(ghost);
+
+    // Exact placement: find the support face + click point whose predicted block
+    // reproduces the ghost (orientation and all). Uses getPlacementBlock, which
+    // is reliable for the orientation-critical full blocks (stairs, slabs,
+    // pistons, ...) this path is meant for.
+    auto const searchExact = [&]() -> bool {
+        auto const tryPlacement = [&](BlockPos const& at, uchar face, Vec3 const& clickPos) {
+            Block const& predicted = ghost.getPlacementBlock(player, cell, face, clickPos, itemAux);
+            if (!(predicted == ghost)) return false;
+            out = ProjectionTarget{cell, at, face, &ghost, clickPos};
+            return true;
+        };
+        for (uchar sf = 0; sf < 6; ++sf) {
+            BlockPos const at = cell.neighbor(sf);
+            if (region.getBlock(at).isAir()) continue;
+            uchar const face = Facing::getOpposite(sf);
+            bool matched = false;
+            forEachClickCandidate(cell, sf, [&](Vec3 const& clickPos) {
+                if (!matched && tryPlacement(at, face, clickPos)) matched = true;
+            });
+            if (matched) return true;
+        }
+        float const cx = static_cast<float>(cell.x);
+        float const cy = static_cast<float>(cell.y);
+        float const cz = static_cast<float>(cell.z);
+        for (uchar face = 0; face < 6; ++face) {
+            if (tryPlacement(cell, face, Vec3{cx + 0.5f, cy + 0.25f, cz + 0.5f})) return true;
+            if (tryPlacement(cell, face, Vec3{cx + 0.5f, cy + 0.75f, cz + 0.5f})) return true;
+        }
+        return false;
+    };
+
+    // Best-effort placement: pick the first real solid support (the block below
+    // is preferred) and let the server resolve the block. getPlacementBlock is
+    // NOT consulted here -- it returns air/defaults for several redstone
+    // components (comparator, redstone dust, hopper, ...), which would otherwise
+    // make them impossible to place.
+    auto const searchAnySupport = [&]() -> bool {
+        for (uchar sf = 0; sf < 6; ++sf) {
+            BlockPos const at = cell.neighbor(sf);
+            if (region.getBlock(at).isAir()) continue;
+            out = ProjectionTarget{cell, at, Facing::getOpposite(sf), &ghost, sharedFaceCenter(cell, sf)};
+            return true;
+        }
+        return false;
+    };
+
+    // Type-only families never orient exactly; place them on any real support.
+    if (typeOnly) return searchAnySupport();
+
+    // Comparators/repeaters: gate on facing only (mode/delay are toggled after).
+    // Facing comes from the player's view, so one support is enough to read the
+    // predicted facing. If getPlacementBlock cannot produce the block at all,
+    // fall back to placing it rather than getting stuck.
+    if (isFacingGate(ghost)) {
+        std::string const wantFacing = facingValue(ghost);
+        for (uchar sf = 0; sf < 6; ++sf) {
+            BlockPos const at = cell.neighbor(sf);
+            if (region.getBlock(at).isAir()) continue;
+            uchar const face = Facing::getOpposite(sf);
+            Vec3 const cp = sharedFaceCenter(cell, sf);
+            Block const& predicted = ghost.getPlacementBlock(player, cell, face, cp, itemAux);
+            if (predicted.getTypeName() != ghost.getTypeName()) continue;
+            if (facingValue(predicted) != wantFacing) return false;  // wrong facing
+            out = ProjectionTarget{cell, at, face, &ghost, cp};
+            return true;
+        }
+        return searchAnySupport();
+    }
+
+    // Orientation-critical blocks: prefer an exact match. Manual mode
+    // (requireExact == false) still places best-effort so a deliberate
+    // right-click is never a no-op.
+    if (searchExact()) return true;
+    if (!requireExact) return searchAnySupport();
+    return false;
+}
+
 void tickRangePlace(LocalPlayer& player) {
     auto const now = GetTickCount64();
     Vec3 const center = player.getPosition();
@@ -322,28 +597,18 @@ void tickRangePlace(LocalPlayer& player) {
     auto candidates = projection::queryMissingCellsInRange(center, radius);
     for (auto const& cand : candidates) {
         BlockPos const cell{cand.x, cand.y, cand.z};
-        Vec3 const toCell{
-            static_cast<float>(cell.x) + 0.5f - center.x,
-            static_cast<float>(cell.y) + 0.5f - center.y,
-            static_cast<float>(cell.z) + 0.5f - center.z
-        };
 
-        // Per-cell lock: the server needs a moment to apply the placement and
-        // the correction scan needs a moment to mark the cell Correct.
-        if (gLastPlaceCell && *gLastPlaceCell == cell
-            && now - gLastPlaceAt.load(std::memory_order_acquire) < kCellLockMs) {
-            continue;
-        }
+        // Skip cells placed a moment ago until the server applies them, so a
+        // cell is never placed twice mid-round-trip (the slab double-place).
+        if (recentlyPlaced(cell, now)) continue;
 
-        // Reuse the easy-place placement chain: shared support selection (with
-        // air-mPos fallback), item lookup, swap, and server transaction.
-        float const dist = std::sqrt(toCell.x * toCell.x + toCell.y * toCell.y + toCell.z * toCell.z);
-        if (dist <= 0.0f) continue;
-        Vec3 const approachDir{toCell.x / dist, toCell.y / dist, toCell.z / dist};
-        auto const target = selectPlacementTarget(region, cell, approachDir, cand.block);
+        // Orientation gate: only place when the resulting block would match the
+        // ghost. The search also picks the support face / click point, replacing
+        // the old approach-based support selection.
+        ProjectionTarget target;
+        if (!resolveOrientedPlacement(player, region, cell, *cand.block, 0, true, target)) continue;
 
-        ItemStack const want(*cand.block, 1, nullptr);
-        auto const found = findItemSlot(player, want);
+        auto const found = findItemSlot(player, *cand.block);
         if (found.slot < 0) continue;
 
         if (found.slot >= kHotbarSlots) {
@@ -358,8 +623,7 @@ void tickRangePlace(LocalPlayer& player) {
             return;
         }
         player.setSelectedSlot(found.slot);
-        gLastPlaceCell = cell;
-        gLastPlaceAt.store(now, std::memory_order_release);
+        markPlaced(cell, now);
         placeBlock(player, target, found.slot, *found.item);
         return;
     }
@@ -398,31 +662,64 @@ void tickEasyPlace() {
     updateAimedBlockEntityName(target ? target->block : nullptr);
 
     if (!gEnabled.load(std::memory_order_acquire)
+        && !gManualMode.load(std::memory_order_acquire)
         && !gRangeEnabled.load(std::memory_order_acquire)) {
         return;
     }
     if (GetTickCount64() < gNextPlaceAt.load(std::memory_order_acquire)) return;
 
-    // Range placement scans everything within the configured radius; it takes
-    // precedence over the single-target easy-place when both are on.
+    // Range placement scans everything within the configured radius.
     if (gRangeEnabled.load(std::memory_order_acquire)) {
         tickRangePlace(*player);
         return;
     }
+
+    // Single-crosshair placement: auto (轻松放置) or manual (手动放置), which are
+    // mutually exclusive in the UI. Manual mode places exactly one block per
+    // right-click press: startBuildBlock sets a one-shot request (consumed by
+    // the placement below); the buildBlock hook cancels the vanilla build so
+    // nothing is placed twice.
+    if (gManualMode.load(std::memory_order_acquire)) {
+        auto const nowManual = GetTickCount64();
+        bool allowed = false;
+        // First block of a press: place it even if the button was already
+        // released (a quick tap), until the request goes stale.
+        if (gManualPlaceRequested.load(std::memory_order_acquire)) {
+            if (nowManual - gManualPressAt.load(std::memory_order_acquire) <= kManualRequestTimeoutMs) {
+                allowed = true;
+            } else {
+                gManualPlaceRequested.store(false, std::memory_order_release);
+            }
+        }
+        // While the button stays held, pause for the initial delay and then
+        // repeat at a steady rate (typematic).
+        if (!allowed && gManualHeld.load(std::memory_order_acquire)
+            && nowManual - gManualPressAt.load(std::memory_order_acquire) >= kManualInitialDelayMs
+            && nowManual - gLastManualPlaceAt.load(std::memory_order_acquire) >= kManualRepeatIntervalMs) {
+            allowed = true;
+        }
+        if (!allowed) return;
+    }
     if (!target) return;
 
-    // Per-cell lock: the server needs a moment to apply the placement and the
-    // correction scan needs a moment to mark the cell Correct. Skip re-sending
-    // the same cell within that window; new cells place immediately.
+    // Skip cells placed a moment ago until the server applies them; new cells
+    // place immediately.
     auto const now = GetTickCount64();
-    if (gLastPlaceCell && *gLastPlaceCell == target->cell
-        && now - gLastPlaceAt.load(std::memory_order_acquire) < kCellLockMs) {
-        return;
-    }
+    if (recentlyPlaced(target->cell, now)) return;
 
-    ItemStack const want(*target->block, 1, nullptr);
-    auto const found = findItemSlot(*player, want);
-    if (found.slot < 0) return;
+    // Orientation gate: only place when the resulting block would match the
+    // ghost. The search picks the click point / support face that reproduces
+    // it; rotational blocks pass only while the player looks the right way.
+    auto& region = player->getDimensionBlockSource();
+    ProjectionTarget placement;
+    // Orientation is angle-gated in both modes: an orientable block places only
+    // when the current view would produce the ghost's facing (like pistons).
+    // Type-only families (rails, redstone, comparators, ...) bypass this.
+    bool const requireExact = true;
+    bool const resolved =
+        resolveOrientedPlacement(*player, region, target->cell, *target->block, 0, requireExact, placement);
+    auto const found = resolved ? findItemSlot(*player, *target->block) : ItemFind{-1, nullptr};
+    if (!resolved || found.slot < 0) return;
 
     if (found.slot >= kHotbarSlots) {
         // Back off a rejected swap so it never retries more often than
@@ -444,9 +741,12 @@ void tickEasyPlace() {
         return;
     }
     player->setSelectedSlot(found.slot);
-    gLastPlaceCell = target->cell;
-    gLastPlaceAt.store(now, std::memory_order_release);
-    placeBlock(*player, *target, found.slot, *found.item);
+    markPlaced(placement.cell, now);
+    placeBlock(*player, placement, found.slot, *found.item);
+    // Manual repeat bookkeeping: record this placement and mark the current
+    // press as having placed its first block (so holding then auto-repeats).
+    gLastManualPlaceAt.store(now, std::memory_order_release);
+    gManualPlaceRequested.store(false, std::memory_order_release);
 }
 
 LL_TYPE_INSTANCE_HOOK(
@@ -459,6 +759,69 @@ LL_TYPE_INSTANCE_HOOK(
 ) {
     tickEasyPlace();
     origin(currentTick);
+}
+
+// Returns true when manual mode is on and `gm` belongs to the local player, i.e.
+// this is the client-side right-click we should take over. The local-player
+// check is essential: the server processes LHolo's own placement through these
+// same functions on the ServerPlayer, and that must not be suppressed.
+bool isLocalManualBuild(GameMode& gm) {
+    if (!gManualMode.load(std::memory_order_acquire)) return false;
+    auto client = ll::service::getClientInstance();
+    auto* localPlayer = client ? client->getLocalPlayer() : nullptr;
+    return localPlayer && &gm.mPlayer == static_cast<Player*>(localPlayer);
+}
+
+// Manual-mode press edge: the initial right-click. Begin a held sequence (first
+// block placed immediately by tickEasyPlace, then typematic repeat) and cancel
+// the vanilla build start so nothing is placed twice.
+LL_TYPE_INSTANCE_HOOK(
+    GameModeStartBuildHook,
+    ll::memory::HookPriority::Normal,
+    GameMode,
+    &GameMode::$startBuildBlock,
+    void,
+    ::BlockPos const& pos,
+    uchar             face
+) {
+    if (isLocalManualBuild(*this)) {
+        gManualPressAt.store(GetTickCount64(), std::memory_order_release);
+        gManualPlaceRequested.store(true, std::memory_order_release);
+        gManualHeld.store(true, std::memory_order_release);
+        return;  // LHolo handles the placement from tickEasyPlace.
+    }
+    origin(pos, face);
+}
+
+// Manual-mode release edge: stop the typematic repeat when the button is let go.
+LL_TYPE_INSTANCE_HOOK(
+    GameModeStopBuildHook,
+    ll::memory::HookPriority::Normal,
+    GameMode,
+    &GameMode::$stopBuildBlock,
+    void
+) {
+    if (isLocalManualBuild(*this)) {
+        gManualHeld.store(false, std::memory_order_release);
+        return;
+    }
+    origin();
+}
+
+// Suppress the vanilla continuous build while the button is held in manual mode;
+// LHolo drives placement from the press/hold state above.
+LL_TYPE_INSTANCE_HOOK(
+    GameModeBuildBlockHook,
+    ll::memory::HookPriority::Normal,
+    GameMode,
+    &GameMode::$buildBlock,
+    bool,
+    ::BlockPos const& pos,
+    uchar             face,
+    bool const        isSimTick
+) {
+    if (isLocalManualBuild(*this)) return false;
+    return origin(pos, face, isSimTick);
 }
 
 } // namespace
@@ -497,6 +860,14 @@ int getPlacementRadius() {
     return gPlacementRadius.load(std::memory_order_relaxed);
 }
 
+void setManualMode(bool manual) {
+    gManualMode.store(manual, std::memory_order_release);
+}
+
+bool isManualMode() {
+    return gManualMode.load(std::memory_order_acquire);
+}
+
 std::string getAimedBlockEntityName() {
     std::lock_guard lock(gAimedNameMutex);
     return gAimedBlockEntityName;
@@ -507,10 +878,22 @@ bool installHook() {
         logger().error("Failed to install easy-place tick hook");
         return false;
     }
+    if (GameModeStartBuildHook::hook() < 0) {
+        logger().warn("Failed to install manual-place start hook; manual mode will be unavailable");
+    }
+    if (GameModeStopBuildHook::hook() < 0) {
+        logger().warn("Failed to install manual-place stop hook; manual mode may keep repeating");
+    }
+    if (GameModeBuildBlockHook::hook() < 0) {
+        logger().warn("Failed to install manual-place build hook; manual mode may double-place");
+    }
     return true;
 }
 
 void uninstallHook() {
+    GameModeBuildBlockHook::unhook();
+    GameModeStopBuildHook::unhook();
+    GameModeStartBuildHook::unhook();
     LocalPlayerEasyPlaceHook::unhook();
 }
 

--- a/src/place/PlaceHelper.h
+++ b/src/place/PlaceHelper.h
@@ -28,6 +28,10 @@ void setRangeEnabled(bool enabled);
 bool isRangeEnabled();
 void setPlacementRadius(int radius);
 int  getPlacementRadius();
+// Manual mode: only place while the right mouse button is held, instead of
+// placing automatically. Applies to both easy-place and range placement.
+void setManualMode(bool manual);
+bool isManualMode();
 // Name of the block-entity block (chest, sign, hopper, ...) the crosshair
 // points at, for the HUD to identify projected placeholder boxes.
 std::string getAimedBlockEntityName();

--- a/src/projection/Projection.cpp
+++ b/src/projection/Projection.cpp
@@ -60,6 +60,10 @@
 #include "mc/network/MinecraftPacketIds.h"
 #include "mc/network/Packet.h"
 #include "mc/network/packet/TextPacket.h"
+#include "mc/deps/nbt/CompoundTag.h"
+#include "mc/deps/nbt/IntTag.h"
+#include "mc/deps/nbt/StringTag.h"
+#include "mc/deps/nbt/Tag.h"
 #include "mc/world/actor/Actor.h"
 #include "mc/world/Facing.h"
 #include "mc/world/level/BlockSource.h"
@@ -410,6 +414,32 @@ bool projectionStatesMatch(Block const& expected, Block const& actual) {
     }
 
     return false;
+}
+
+// Front face (Facing 0-5) for a block-entity placeholder, read from whichever
+// facing state the block actually carries. Chests and similar block entities
+// moved from the integer facing_direction to the string
+// minecraft:cardinal_direction, so both are handled. Returns -1 when the block
+// has no horizontal facing.
+int blockFrontFace(Block const& block) {
+    for (auto const& [key, value] : block.getSerializationId()) {
+        if (key != "states") continue;
+        if (!value.hold<CompoundTag>()) break;
+        for (auto const& [stateKey, stateValue] : value.get<CompoundTag>()) {
+            if (stateKey == "facing_direction" && stateValue.getId() == Tag::Type::Int) {
+                return stateValue.get<IntTag>().data;
+            }
+            if (stateKey == "minecraft:cardinal_direction" && stateValue.getId() == Tag::Type::String) {
+                std::string const& facing = static_cast<std::string const&>(stateValue.get<StringTag>());
+                if (facing == "north") return static_cast<int>(Facing::Name::North);
+                if (facing == "south") return static_cast<int>(Facing::Name::South);
+                if (facing == "west")  return static_cast<int>(Facing::Name::West);
+                if (facing == "east")  return static_cast<int>(Facing::Name::East);
+            }
+        }
+        break;
+    }
+    return -1;
 }
 
 BlockPos transformStructurePosition(
@@ -955,10 +985,7 @@ void renderProjection(BaseActorRenderContext& renderContext, bool renderAlphaLay
                     bool const isSign = expectedBlock->getTypeName().find("sign") != std::string::npos;
                     // Facing (FacingDirection state: North=2 South=3 West=4 East=5)
                     // decides which cube face is the block's front.
-                    int frontFace = -1;
-                    if (auto const facing = expectedBlock->getState<int>(VanillaStates::FacingDirection())) {
-                        frontFace = *facing;
-                    }
+                    int const frontFace = blockFrontFace(*expectedBlock);
                     float const px = static_cast<float>(p.x);
                     float const py = static_cast<float>(p.y);
                     float const pz = static_cast<float>(p.z);

--- a/src/structure/JavaBlockMapping.cpp
+++ b/src/structure/JavaBlockMapping.cpp
@@ -1,0 +1,511 @@
+// LHolo - Client-side projection renderer for Minecraft Bedrock Windows
+// Copyright (C) 2026  MarmieQi
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+// Java -> Bedrock block-state translation for the .litematic loader.
+//
+// The .mcstructure path goes through the vanilla StructureTemplate loader,
+// which upgrades and preserves every block state. Java `.litematic` files carry
+// Java Edition names and Java property strings, so this module reproduces the
+// missing step: map the Java state to the equivalent Bedrock state and resolve
+// it to a real Bedrock block.
+//
+// Design (adapted from the LitematicaBE mapping module, minus its TSV table and
+// server-side ghost/packet machinery, which do not apply to LHolo's client-side
+// tessellator):
+//
+//   1. Look up the Bedrock block by name and enumerate its permutations, once
+//      per name, caching the real state key/value strings of each variant.
+//   2. Inspect which state keys the block actually has, and emit only the
+//      Bedrock states that exist on it, converting Java property values with the
+//      per-family rules below (verified facing/weirdo/trapdoor tables come from
+//      LitematicaBE's StateSemantics).
+//   3. Resolve by partial match: the first permutation whose specified states
+//      all agree wins; if none match, fall back to the default permutation.
+//
+// Because emitted states are gated on the block's real schema and matching
+// always has a same-type fallback, an imperfect mapping degrades to "correct
+// block, default orientation" rather than a crash or a garbage block.
+
+#include "structure/JavaBlockMapping.h"
+
+#include <algorithm>
+#include <cstdlib>
+#include <mutex>
+#include <string>
+#include <string_view>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+#include "mc/deps/core/string/HashedString.h"
+#include "mc/deps/nbt/ByteTag.h"
+#include "mc/deps/nbt/CompoundTag.h"
+#include "mc/deps/nbt/IntTag.h"
+#include "mc/deps/nbt/StringTag.h"
+#include "mc/deps/nbt/Tag.h"
+#include "mc/world/level/block/Block.h"
+#include "mc/world/level/block/BlockType.h"
+#include "mc/world/level/block/registry/BlockTypeRegistry.h"
+#include "mc/world/level/material/Material.h"
+
+namespace lholo::structure {
+namespace {
+
+using StatePairs = std::vector<std::pair<std::string, std::string>>;
+
+// -----------------------------------------------------------------------------
+// Name classification helpers
+// -----------------------------------------------------------------------------
+
+bool endsWith(std::string const& s, std::string_view suffix) {
+    return s.size() >= suffix.size()
+        && s.compare(s.size() - suffix.size(), suffix.size(), suffix) == 0;
+}
+
+bool isStairs(std::string const& name) { return endsWith(name, "_stairs"); }
+bool isTrapdoor(std::string const& name) {
+    return endsWith(name, "_trapdoor") || name == "minecraft:trapdoor";
+}
+bool isDoor(std::string const& name) {
+    return endsWith(name, "_door") && !endsWith(name, "_trapdoor");
+}
+bool isWall(std::string const& name) { return endsWith(name, "_wall"); }
+
+// Blocks the game generates on its own (piston heads, portals, fire, ...). The
+// projection skips them so the user is never asked to place an unobtainable
+// block. Straight from LitematicaBE's isDerivedBlock.
+bool isDerivedBlock(std::string const& name) {
+    return name == "minecraft:piston_head"
+        || name == "minecraft:moving_piston"
+        || name == "minecraft:bubble_column"
+        || name == "minecraft:fire"
+        || name == "minecraft:soul_fire"
+        || name == "minecraft:frosted_ice"
+        || name == "minecraft:nether_portal"
+        || name == "minecraft:end_portal"
+        || name == "minecraft:end_gateway";
+}
+
+// Java blocks that sit in water without a `waterlogged` property. On Bedrock the
+// water must be placed on the second layer explicitly.
+bool isImplicitlyWaterlogged(std::string const& name) {
+    return name == "minecraft:seagrass"
+        || name == "minecraft:tall_seagrass"
+        || name == "minecraft:kelp"
+        || name == "minecraft:kelp_plant"
+        || name == "minecraft:tube_coral"
+        || name == "minecraft:brain_coral"
+        || name == "minecraft:bubble_coral"
+        || name == "minecraft:fire_coral"
+        || name == "minecraft:horn_coral"
+        || name == "minecraft:tube_coral_fan"
+        || name == "minecraft:brain_coral_fan"
+        || name == "minecraft:bubble_coral_fan"
+        || name == "minecraft:fire_coral_fan"
+        || name == "minecraft:horn_coral_fan";
+}
+
+// -----------------------------------------------------------------------------
+// Java facing/value conversion tables (verified in LitematicaBE)
+// -----------------------------------------------------------------------------
+
+// Bedrock `facing_direction` (down/up/north/south/west/east).
+int standardFacingDirection(std::string const& facing) {
+    if (facing == "down")  return 0;
+    if (facing == "up")    return 1;
+    if (facing == "north") return 2;
+    if (facing == "south") return 3;
+    if (facing == "west")  return 4;
+    if (facing == "east")  return 5;
+    return -1;
+}
+
+// Bedrock stair `weirdo_direction`.
+int weirdoDirection(std::string const& facing) {
+    if (facing == "east")  return 0;
+    if (facing == "west")  return 1;
+    if (facing == "south") return 2;
+    if (facing == "north") return 3;
+    return -1;
+}
+
+// Bedrock trapdoor `direction`.
+int trapdoorDirection(std::string const& facing) {
+    if (facing == "east")  return 0;
+    if (facing == "west")  return 1;
+    if (facing == "south") return 2;
+    if (facing == "north") return 3;
+    return -1;
+}
+
+// Bedrock door `direction`. Java `facing` is the direction the closed door
+// faces; Bedrock stores the same four directions on `direction`.
+int doorDirection(std::string const& facing) {
+    if (facing == "east")  return 0;
+    if (facing == "south") return 1;
+    if (facing == "west")  return 2;
+    if (facing == "north") return 3;
+    return -1;
+}
+
+// Java wall connection height (none/low/tall) -> Bedrock wall_connection_type.
+std::string wallConnection(std::string const& value) {
+    if (value == "tall") return "tall";
+    if (value == "low")  return "short";
+    return "none";
+}
+
+// Java rail `shape` -> Bedrock `rail_direction` (identical index order).
+int railDirection(std::string const& shape) {
+    if (shape == "north_south")     return 0;
+    if (shape == "east_west")       return 1;
+    if (shape == "ascending_east")  return 2;
+    if (shape == "ascending_west")  return 3;
+    if (shape == "ascending_north") return 4;
+    if (shape == "ascending_south") return 5;
+    if (shape == "south_east")      return 6;
+    if (shape == "south_west")      return 7;
+    if (shape == "north_west")      return 8;
+    if (shape == "north_east")      return 9;
+    return -1;
+}
+
+// Opposite horizontal facing; up/down unchanged.
+std::string flipHorizontal(std::string const& facing) {
+    if (facing == "north") return "south";
+    if (facing == "south") return "north";
+    if (facing == "west")  return "east";
+    if (facing == "east")  return "west";
+    return facing;
+}
+
+// Swap only the east/west axis. Repeaters/comparators and torches came out
+// mirrored on X in-game (verified against the actual game, not the reference
+// table), while other cardinal_direction blocks like chests were correct.
+std::string swapEastWest(std::string const& facing) {
+    if (facing == "east") return "west";
+    if (facing == "west") return "east";
+    return facing;
+}
+
+// Repeaters and comparators (diodes) whose cardinal_direction needs the X swap.
+bool isDiode(std::string const& name) {
+    return name == "minecraft:unpowered_repeater" || name == "minecraft:powered_repeater"
+        || name == "minecraft:unpowered_comparator" || name == "minecraft:powered_comparator";
+}
+
+bool isLever(std::string const& name)  { return name == "minecraft:lever"; }
+bool isButton(std::string const& name) { return endsWith(name, "_button"); }
+bool isRail(std::string const& name) {
+    return name == "minecraft:rail" || name == "minecraft:golden_rail"
+        || name == "minecraft:detector_rail" || name == "minecraft:activator_rail";
+}
+
+// Pistons face the opposite horizontal way between editions; their up/down
+// orientation already matches, so only the horizontal cardinal is flipped.
+// (Confirmed in testing: only pistons need this; hoppers/droppers/observers are
+// already correct with the standard facing.)
+bool flipsHorizontalFacing(std::string const& name) {
+    return name == "minecraft:piston" || name == "minecraft:sticky_piston";
+}
+
+// Java lever (face + facing) -> Bedrock `lever_direction` string.
+std::string leverDirection(std::string const& face, std::string const& facing) {
+    bool const axisEastWest = (facing == "east" || facing == "west");
+    if (face == "floor")   return axisEastWest ? "up_east_west"   : "up_north_south";
+    if (face == "ceiling") return axisEastWest ? "down_east_west" : "down_north_south";
+    if (facing == "north" || facing == "south" || facing == "east" || facing == "west") {
+        return facing;  // wall-mounted: points out along `facing`
+    }
+    return "north";
+}
+
+// Java button/grindstone `face`+`facing` -> Bedrock `facing_direction` (0-5).
+int mountedFacingDirection(std::string const& face, std::string const& facing) {
+    if (face == "floor")   return 1;  // up
+    if (face == "ceiling") return 0;  // down
+    return standardFacingDirection(facing);
+}
+
+// Java -> Bedrock block name renames (only the ones that actually differ, so
+// they resolve instead of silently vanishing).
+std::string bedrockName(std::string const& java) {
+    static std::unordered_map<std::string, std::string> const kRenames = {
+        {"minecraft:note_block", "minecraft:noteblock"},
+        {"minecraft:powered_rail", "minecraft:golden_rail"},
+        {"minecraft:lily_pad", "minecraft:waterlily"},
+        {"minecraft:cobweb", "minecraft:web"},
+        {"minecraft:dirt_path", "minecraft:grass_path"},
+        {"minecraft:magma_block", "minecraft:magma"},
+        {"minecraft:nether_quartz_ore", "minecraft:quartz_ore"},
+        {"minecraft:snow_block", "minecraft:snow"},
+        {"minecraft:snow", "minecraft:snow_layer"},
+        {"minecraft:wall_torch", "minecraft:torch"},
+        {"minecraft:soul_wall_torch", "minecraft:soul_torch"},
+        {"minecraft:redstone_wall_torch", "minecraft:redstone_torch"},
+        {"minecraft:comparator", "minecraft:unpowered_comparator"},
+        {"minecraft:repeater", "minecraft:unpowered_repeater"},
+    };
+    auto const it = kRenames.find(java);
+    return it == kRenames.end() ? java : it->second;
+}
+
+// -----------------------------------------------------------------------------
+// Permutation cache: name -> every variant's (state key/value strings, block)
+// -----------------------------------------------------------------------------
+
+struct PermTable {
+    std::vector<std::pair<StatePairs, Block const*>> perms;
+};
+
+std::mutex                                  gCacheMutex;
+std::unordered_map<std::string, PermTable>  gPermCache;
+Block const*                                gWaterSource = nullptr;
+bool                                        gWaterResolved = false;
+
+// Read a block's serialized `states` compound into (key, value) string pairs.
+StatePairs readBlockStates(Block const& block) {
+    StatePairs out;
+    for (auto const& [key, value] : block.getSerializationId()) {
+        if (key != "states") continue;
+        if (!value.hold<::CompoundTag>()) break;
+        for (auto const& [stateKey, stateValue] : value.get<::CompoundTag>()) {
+            switch (stateValue.getId()) {
+            case ::Tag::Type::Byte:
+                out.emplace_back(stateKey, std::to_string(static_cast<int>(stateValue.get<::ByteTag>().data)));
+                break;
+            case ::Tag::Type::Int:
+                out.emplace_back(stateKey, std::to_string(stateValue.get<::IntTag>().data));
+                break;
+            case ::Tag::Type::String:
+                out.emplace_back(stateKey, static_cast<std::string const&>(stateValue.get<::StringTag>()));
+                break;
+            default:
+                break;
+            }
+        }
+        break;
+    }
+    return out;
+}
+
+// Caller holds gCacheMutex. Returns an empty table for unknown names.
+PermTable const& permutationsFor(std::string const& name) {
+    auto const cached = gPermCache.find(name);
+    if (cached != gPermCache.end()) return cached->second;
+
+    PermTable table;
+    auto const& def = BlockTypeRegistry::get().getDefaultBlockState(HashedString(name), false);
+    // getDefaultBlockState returns air for unknown names; only enumerate when the
+    // resolved type genuinely matches the requested name.
+    if (def.getTypeName() == name) {
+        def.getBlockType().forEachBlockPermutation([&](Block const& permutation) {
+            table.perms.emplace_back(readBlockStates(permutation), &permutation);
+            return true;
+        });
+    }
+    auto const inserted = gPermCache.emplace(name, std::move(table)).first;
+    return inserted->second;
+}
+
+Block const* waterSource() {
+    if (!gWaterResolved) {
+        auto const& def = BlockTypeRegistry::get().getDefaultBlockState(HashedString("minecraft:water"), false);
+        gWaterSource   = def.isAir() ? nullptr : &def;
+        gWaterResolved = true;
+    }
+    return gWaterSource;
+}
+
+// -----------------------------------------------------------------------------
+// Java properties -> Bedrock states (gated on the block's real state schema)
+// -----------------------------------------------------------------------------
+
+StatePairs mapProperties(
+    std::string const&                                      name,
+    std::vector<std::pair<std::string, std::string>> const& properties,
+    std::unordered_set<std::string> const&                  keys
+) {
+    StatePairs requested;
+    auto const has  = [&](char const* key) { return keys.count(key) != 0; };
+    auto const emit = [&](std::string key, std::string value) {
+        requested.emplace_back(std::move(key), std::move(value));
+    };
+    auto const find = [&](char const* key) -> std::string {
+        for (auto const& [pk, pv] : properties) if (pk == key) return pv;
+        return {};
+    };
+
+    bool const lever  = isLever(name);
+    bool const button = isButton(name);
+    bool const rail   = isRail(name);
+    bool const flipH  = flipsHorizontalFacing(name);
+    bool const torch  = has("torch_facing_direction");
+
+    // Multi-property families: consume `face`/`facing`/`shape` up front so the
+    // per-property loop below does not also touch them.
+    if (lever && has("lever_direction")) {
+        emit("lever_direction", leverDirection(find("face"), find("facing")));
+    }
+    if (button && has("facing_direction")) {
+        int const d = mountedFacingDirection(find("face"), find("facing"));
+        if (d >= 0) emit("facing_direction", std::to_string(d));
+    }
+    if (rail && has("rail_direction")) {
+        int const d = railDirection(find("shape"));
+        if (d >= 0) emit("rail_direction", std::to_string(d));
+    }
+    if (torch) {
+        // Wall torches carry `facing`; standing torches have none -> "top".
+        // Bedrock names the wall side (opposite of Java on north/south), but the
+        // east/west axis came out mirrored in-game, so undo the X flip.
+        std::string const f = find("facing");
+        emit("torch_facing_direction", f.empty() ? "top" : swapEastWest(flipHorizontal(f)));
+    }
+
+    for (auto const& [key, value] : properties) {
+        if (key == "facing") {
+            if (lever || button || torch) continue;  // already consumed above
+            std::string const f = flipH ? flipHorizontal(value) : value;
+            if (has("weirdo_direction")) {
+                int const d = weirdoDirection(f);
+                if (d >= 0) emit("weirdo_direction", std::to_string(d));
+            } else if (has("facing_direction")) {
+                int const d = standardFacingDirection(f);
+                if (d >= 0) emit("facing_direction", std::to_string(d));
+            } else if (has("minecraft:cardinal_direction")) {
+                emit("minecraft:cardinal_direction", isDiode(name) ? swapEastWest(f) : f);
+            } else if (has("minecraft:facing_direction")) {
+                emit("minecraft:facing_direction", f);
+            } else if (has("direction")) {
+                int const d = isDoor(name) ? doorDirection(f) : trapdoorDirection(f);
+                if (d >= 0) emit("direction", std::to_string(d));
+            }
+        } else if (key == "half") {
+            // Stairs/trapdoors: top vs bottom. Doors/tall plants: upper vs lower.
+            if (has("upside_down_bit"))         emit("upside_down_bit", value == "top" ? "1" : "0");
+            if (has("upper_block_bit"))         emit("upper_block_bit", value == "upper" ? "1" : "0");
+            if (has("minecraft:vertical_half")) emit("minecraft:vertical_half", value);
+        } else if (key == "type") {
+            // Slabs: top/bottom (double slabs are a separate block, left as-is).
+            if (value != "double") {
+                if (has("minecraft:vertical_half")) emit("minecraft:vertical_half", value);
+                else if (has("top_slot_bit"))       emit("top_slot_bit", value == "top" ? "1" : "0");
+            }
+        } else if (key == "axis") {
+            if (has("pillar_axis")) emit("pillar_axis", value);
+        } else if (key == "open") {
+            if (has("open_bit")) emit("open_bit", value == "true" ? "1" : "0");
+        } else if (key == "hinge") {
+            if (has("door_hinge_bit")) emit("door_hinge_bit", value == "right" ? "1" : "0");
+        } else if (key == "level") {
+            // Water/lava fill. Bedrock liquid_depth mirrors the Java level number.
+            if (has("liquid_depth")) emit("liquid_depth", value);
+        } else if (key == "delay") {
+            // Repeater: Java delay 1..4 -> Bedrock repeater_delay 0..3.
+            if (has("repeater_delay")) {
+                int const d = std::atoi(value.c_str()) - 1;
+                if (d >= 0 && d <= 3) emit("repeater_delay", std::to_string(d));
+            }
+        } else if (key == "mode") {
+            // Comparator: compare/subtract.
+            if (has("output_subtract_bit")) emit("output_subtract_bit", value == "subtract" ? "1" : "0");
+        } else if (key == "powered") {
+            if (rail && has("rail_data_bit"))    emit("rail_data_bit", value == "true" ? "1" : "0");
+            else if (has("button_pressed_bit"))  emit("button_pressed_bit", value == "true" ? "1" : "0");
+        } else if (key == "rotation") {
+            // Standing signs / banners, 0..15.
+            if (has("ground_sign_direction")) emit("ground_sign_direction", value);
+        } else if (key == "north" || key == "east" || key == "south" || key == "west") {
+            if (isWall(name)) {
+                std::string const stateKey = "wall_connection_type_" + key;
+                if (has(stateKey.c_str())) emit(stateKey, wallConnection(value));
+            }
+        } else if (key == "up") {
+            if (isWall(name) && has("wall_post_bit")) emit("wall_post_bit", value == "true" ? "1" : "0");
+        }
+        // Other Java properties (shape on non-rails, snowy, distance, ...) are
+        // intentionally ignored: neighbor-derived (recomputed by Bedrock at
+        // render time) or handled separately (waterlogged in the caller).
+    }
+    return requested;
+}
+
+// First permutation whose requested states all agree; else the default variant.
+Block const* resolvePermutation(PermTable const& table, StatePairs const& requested) {
+    if (table.perms.empty()) return nullptr;
+    for (auto const& [states, block] : table.perms) {
+        bool matches = true;
+        for (auto const& [key, value] : requested) {
+            auto const found = std::find_if(states.begin(), states.end(),
+                [&](auto const& s) { return s.first == key; });
+            if (found == states.end() || found->second != value) {
+                matches = false;
+                break;
+            }
+        }
+        if (matches) return block;
+    }
+    return table.perms.front().second;
+}
+
+} // namespace
+
+ResolvedJavaBlock resolveJavaBlockState(
+    std::string const&                                      javaName,
+    std::vector<std::pair<std::string, std::string>> const& properties
+) {
+    if (javaName.empty() || javaName == "minecraft:air") return {};
+    if (isDerivedBlock(javaName)) return {};
+
+    // Some blocks are named differently on Bedrock; translate before lookup so
+    // they resolve instead of silently disappearing.
+    std::string const name = bedrockName(javaName);
+
+    std::lock_guard lock(gCacheMutex);
+
+    auto const& table = permutationsFor(name);
+    if (table.perms.empty()) return {};  // Unknown on Bedrock; caller skips it.
+
+    // Which Bedrock states does this block actually carry?
+    std::unordered_set<std::string> keys;
+    for (auto const& [key, value] : table.perms.front().first) keys.insert(key);
+
+    auto const requested = mapProperties(name, properties, keys);
+    Block const* resolved = resolvePermutation(table, requested);
+    if (resolved && resolved->isAir()) resolved = nullptr;
+
+    // Waterlogged: explicit property or an implicitly submerged block.
+    bool waterlogged = isImplicitlyWaterlogged(javaName);
+    if (!waterlogged) {
+        for (auto const& [key, value] : properties) {
+            if (key == "waterlogged" && value == "true") { waterlogged = true; break; }
+        }
+    }
+
+    ResolvedJavaBlock result;
+    if (resolved && resolved->getMaterial().isLiquid()) {
+        // A Java liquid block feeds the liquid layer, matching .mcstructure.
+        result.liquid = resolved;
+    } else {
+        result.block = resolved;
+        if (waterlogged) result.liquid = waterSource();
+    }
+    return result;
+}
+
+} // namespace lholo::structure

--- a/src/structure/JavaBlockMapping.h
+++ b/src/structure/JavaBlockMapping.h
@@ -1,0 +1,48 @@
+// LHolo - Client-side projection renderer for Minecraft Bedrock Windows
+// Copyright (C) 2026  MarmieQi
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+#pragma once
+
+#include <string>
+#include <utility>
+#include <vector>
+
+class Block;
+
+namespace lholo::structure {
+
+// The result of resolving one Java block state (name + properties) to Bedrock.
+// A cell may carry both a solid block and a liquid at once (waterlogged blocks
+// and Java liquids both feed the `liquid` slot), matching the two-layer
+// RenderBlock model shared with the .mcstructure path.
+struct ResolvedJavaBlock {
+    Block const* block  = nullptr;  // Solid/body block; nullptr for pure liquids,
+                                    // air, unknown names, and game-derived blocks.
+    Block const* liquid = nullptr;  // Water/lava layer; nullptr when dry.
+};
+
+// Translate a Java Edition block state to a Bedrock block, carrying over
+// orientation and other stored states (facing, stairs half, log axis, wall
+// connections, waterlogged, ...). Unknown properties are ignored and states
+// that a block does not actually have are never emitted, so the result always
+// resolves to at least the correct block type. `properties` is the Java
+// `Properties` compound as (key, value) string pairs.
+ResolvedJavaBlock resolveJavaBlockState(
+    std::string const&                                       javaName,
+    std::vector<std::pair<std::string, std::string>> const& properties
+);
+
+} // namespace lholo::structure

--- a/src/structure/StructureLoader.cpp
+++ b/src/structure/StructureLoader.cpp
@@ -16,6 +16,7 @@
 
 #include "structure/StructureLoader.h"
 
+#include "structure/JavaBlockMapping.h"
 #include "place/PlaceHelper.h"
 #include "plugin/LHolo.h"
 #include "projection/Projection.h"
@@ -540,12 +541,23 @@ std::optional<std::string> inflateGzip(std::string_view compressed, std::string&
     return output;
 }
 
-Block const* resolveJavaBlock(JavaNbtTag const& paletteEntry) {
+ResolvedJavaBlock resolveJavaBlock(JavaNbtTag const& paletteEntry) {
     auto const* compound = std::get_if<JavaNbtTag::Compound>(&paletteEntry.value);
-    if (!compound) return nullptr;
+    if (!compound) return {};
     auto const* name = javaValue<std::string>(*compound, "Name");
-    if (!name || name->empty()) return nullptr;
-    return BlockTypeRegistry::get().lookupByName(HashedString{*name}, 0, false);
+    if (!name || name->empty()) return {};
+    // Carry the Java `Properties` (all string values) into the mapper so that
+    // orientation and other stored states survive the Java -> Bedrock crossing.
+    std::vector<std::pair<std::string, std::string>> properties;
+    if (auto const* props = javaValue<JavaNbtTag::Compound>(*compound, "Properties")) {
+        properties.reserve(props->size());
+        for (auto const& [key, value] : *props) {
+            if (auto const* text = std::get_if<std::string>(&value.value)) {
+                properties.emplace_back(key, *text);
+            }
+        }
+    }
+    return resolveJavaBlockState(*name, properties);
 }
 
 std::uint32_t packedPaletteIndex(
@@ -705,7 +717,7 @@ std::shared_ptr<LoadedStructure> loadLitematic(std::filesystem::path const& path
         int posX{}, posY{}, posZ{};
         int signedX{}, signedY{}, signedZ{};
         int sizeX{}, sizeY{}, sizeZ{};
-        std::vector<Block const*> palette;
+        std::vector<ResolvedJavaBlock> palette;
         JavaNbtTag::LongArray const* states{};
     };
     std::vector<Region> parsedRegions;
@@ -781,7 +793,7 @@ std::shared_ptr<LoadedStructure> loadLitematic(std::filesystem::path const& path
     loaded->volume = static_cast<std::uint64_t>(extentX)
         * static_cast<std::uint64_t>(extentY) * static_cast<std::uint64_t>(extentZ);
     loaded->paletteEntries = paletteEntries;
-    std::unordered_map<std::uint64_t, Block const*> mergedBlocks;
+    std::unordered_map<std::uint64_t, ResolvedJavaBlock> mergedBlocks;
 
     for (auto const& region : parsedRegions) {
         auto const regionVolume = static_cast<std::uint64_t>(region.sizeX)
@@ -798,8 +810,8 @@ std::shared_ptr<LoadedStructure> loadLitematic(std::filesystem::path const& path
         for (std::uint64_t index = 0; index < regionVolume; ++index) {
             auto const paletteIndex = packedPaletteIndex(*region.states, index, bits);
             if (paletteIndex >= region.palette.size()) continue;
-            auto const* block = region.palette[paletteIndex];
-            if (!block || block->isAir()) continue;
+            auto const& resolved = region.palette[paletteIndex];
+            if (!resolved.block && !resolved.liquid) continue;
             auto const layer = static_cast<std::uint64_t>(region.sizeX) * region.sizeZ;
             auto const localY = index / layer;
             auto const remainder = index % layer;
@@ -816,28 +828,23 @@ std::shared_ptr<LoadedStructure> loadLitematic(std::filesystem::path const& path
             auto const z = static_cast<std::uint64_t>(worldZ - minZ);
             auto const mergedIndex = (x * static_cast<std::uint64_t>(loaded->sizeY) + y)
                 * static_cast<std::uint64_t>(loaded->sizeZ) + z;
-            mergedBlocks.insert_or_assign(mergedIndex, block);
+            mergedBlocks.insert_or_assign(mergedIndex, resolved);
         }
     }
     loaded->renderBlocks.reserve(mergedBlocks.size());
     auto const yz = static_cast<std::uint64_t>(loaded->sizeY) * loaded->sizeZ;
-    for (auto const& [index, block] : mergedBlocks) {
+    for (auto const& [index, resolved] : mergedBlocks) {
         auto const x = index / yz;
         auto const remainder = index % yz;
         auto const y = remainder / static_cast<std::uint64_t>(loaded->sizeZ);
         auto const z = remainder % static_cast<std::uint64_t>(loaded->sizeZ);
-        // Java litematics have no dual block/liquid layers: route liquid
-        // blocks into the liquid slot so both formats share correction and
-        // proxy-rendering semantics.
-        if (block->getMaterial().isLiquid()) {
-            loaded->renderBlocks.push_back({
-                static_cast<int>(x), static_cast<int>(y), static_cast<int>(z), nullptr, block
-            });
-        } else {
-            loaded->renderBlocks.push_back({
-                static_cast<int>(x), static_cast<int>(y), static_cast<int>(z), block, nullptr
-            });
-        }
+        // The Java -> Bedrock mapper already split each cell into its body and
+        // liquid layers (pure liquids, and the water that waterlogged blocks
+        // carry), matching the two-layer semantics of the .mcstructure path.
+        loaded->renderBlocks.push_back({
+            static_cast<int>(x), static_cast<int>(y), static_cast<int>(z),
+            resolved.block, resolved.liquid
+        });
     }
     std::sort(loaded->renderBlocks.begin(), loaded->renderBlocks.end(), [](auto const& left, auto const& right) {
         return std::tie(left.x, left.y, left.z) < std::tie(right.x, right.y, right.z);
@@ -1461,14 +1468,24 @@ void renderGui() {
             projection::setStructureBoundsEnabled(structureBoundsEnabled);
             saveSettings();
         }
+        // 轻松放置 / 手动放置 / 范围放置 are mutually exclusive placement modes:
+        // enabling one clears the others so only a single mode is ever active.
         auto easyPlaceEnabled = place::isEnabled();
         if (ImGui::Checkbox("轻松放置（准心对准投影方块自动放置）", &easyPlaceEnabled)) {
             place::setEnabled(easyPlaceEnabled);
+            if (easyPlaceEnabled) { place::setManualMode(false); place::setRangeEnabled(false); }
+            saveSettings();
+        }
+        auto manualPlace = place::isManualMode();
+        if (ImGui::Checkbox("手动放置（右键放置·按住连放）", &manualPlace)) {
+            place::setManualMode(manualPlace);
+            if (manualPlace) { place::setEnabled(false); place::setRangeEnabled(false); }
             saveSettings();
         }
         auto rangeEnabled = place::isRangeEnabled();
         if (ImGui::Checkbox("范围放置（自动放置周围投影缺块）", &rangeEnabled)) {
             place::setRangeEnabled(rangeEnabled);
+            if (rangeEnabled) { place::setEnabled(false); place::setManualMode(false); }
             saveSettings();
         }
         auto placementRadius = place::getPlacementRadius();
@@ -1805,6 +1822,7 @@ void loadSettings() {
         gHudShowBlockEntity.store(json.value("hudShowBlockEntity", true), std::memory_order_relaxed);
         gHudPosition.store(std::clamp(json.value("hudPosition", 1), 0, 3), std::memory_order_relaxed);
         place::setEnabled(json.value("easyPlaceEnabled", false));
+        place::setManualMode(json.value("easyPlaceManual", false));
         place::setRangeEnabled(json.value("rangePlaceEnabled", false));
         place::setPlacementRadius(std::clamp(json.value("placementRadius", 4), 1, 4));
         gGuiHotkey.store(std::clamp(json.value("guiHotkey", static_cast<int>('M')), 0, 255), std::memory_order_relaxed);
@@ -1908,7 +1926,7 @@ void saveSettings() {
             savedStructurePath = gSavedStructurePath;
         }
         nlohmann::ordered_json const json{
-            {"version", 6},
+            {"version", 7},
             {"lastStructurePath", lastPath},
             {"uiScale", gUiScale.load(std::memory_order_relaxed)},
             {"opacity", projection::getOpacity()},
@@ -1916,6 +1934,7 @@ void saveSettings() {
             {"correctionOutlineOpacity", projection::getCorrectionOutlineOpacity()},
             {"structureBoundsEnabled", projection::getStructureBoundsEnabled()},
             {"easyPlaceEnabled", place::isEnabled()},
+            {"easyPlaceManual", place::isManualMode()},
             {"rangePlaceEnabled", place::isRangeEnabled()},
             {"placementRadius", place::getPlacementRadius()},
             {"hudEnabled", gHudEnabled.load(std::memory_order_relaxed)},

--- a/xmake.lua
+++ b/xmake.lua
@@ -14,7 +14,7 @@ option_end()
 
 add_repositories("levimc-repo " .. (get_config("levimc_repo") or "https://github.com/LiteLDev/xmake-repo.git"))
 
-add_requires("levilamina 26.20.0", {configs = {target_type = get_config("target_type") or "client"}})
+add_requires("levilamina 26.20.7", {configs = {target_type = get_config("target_type") or "client"}})
 add_requires("levibuildscript")
 add_requires("imgui v1.91.9", {configs = {shared = false, win32 = true, dx11 = true, no_demo_windows = true}})
 add_requires("minhook", {configs = {shared = false}})


### PR DESCRIPTION
- Bump LeviLamina build dependency 26.20.0 -> 26.20.7 (still MC 1.26.20).
- Add Java -> Bedrock block-state mapping for .litematic (new src/structure/JavaBlockMapping.{h,cpp} + StructureLoader wiring). Previously only the block Name was read and the whole Properties compound was dropped, so orientation / connections / waterlogged were all wrong (.mcstructure was unaffected). Now parses Properties and maps facing / stairs half / axis / wall connections / waterlogged / water level, handles item!=block renames (note_block, powered_rail, comparator, repeater, wall_torch, ...), and resolves via permutation matching so a wrong guess degrades to the default block. Repeater / comparator / redstone-torch east-west corrected from in-game testing.
- Block-entity placeholder (chests, ...) now reads minecraft:cardinal_direction as well as facing_direction so it orients on current versions.
- Easy-place: orientation gate (place only when the placed block would match the ghost), facing-only gate for diodes and facing blocks, type-only for rails/redstone; manual mode (hold right-click, tap=one / hold=typematic repeat) via GameMode start/stop/buildBlock hooks, mutually exclusive with auto/range placement; inventory lookup by real item name and item+aux; slab double-placement fix.
- Config version 6 -> 7 (easyPlaceManual).