### PR TITLE
Ensure closing a projection always takes effect

### DIFF
--- a/src/projection/Projection.cpp
+++ b/src/projection/Projection.cpp
@@ -2107,12 +2107,21 @@ LL_TYPE_INSTANCE_HOOK(
     }
     gCaptureBounds.render(renderContext, renderAlphaLayer);
 
-    if (auto loaded = structure::getLoaded(); loaded && loaded->generation != gState.structureGeneration) {
-        clearProjectionStateLocked();
-        if (!enableStructureProjection(renderContext, std::move(loaded))) {
+    if (auto loaded = structure::getLoaded()) {
+        if (loaded->generation != gState.structureGeneration) {
             clearProjectionStateLocked();
-            logger().error("Could not enable loaded structure projection");
+            if (!enableStructureProjection(renderContext, std::move(loaded))) {
+                clearProjectionStateLocked();
+                logger().error("Could not enable loaded structure projection");
+            }
         }
+    } else if (gState.enabled) {
+        // No structure is loaded, yet a projection is still live. This happens
+        // when closeProjection() cleared the loaded structure on another thread
+        // right after a frame had already rebuilt gState from the not-yet-cleared
+        // structure (gState holds its own shared_ptr, so clearing gLoaded alone
+        // never stops it). Tear the projection down so "close" always takes.
+        clearProjectionStateLocked();
     }
 
     if (!gState.enabled) return;

--- a/src/structure/StructureLoader.cpp
+++ b/src/structure/StructureLoader.cpp
@@ -1676,7 +1676,14 @@ lholo::ui::MenuActions makeMenuActions(bool& refreshModel) {
         refreshModel = true;
         logger().info("Restoring projection {} at ({}, {}, {})", savedPath, x, y, z);
     };
-    actions.closeProjection = [] { projection::disable(); clear(); };
+    actions.closeProjection = [&refreshModel] {
+        // Clear the loaded structure BEFORE disabling so a render frame can never
+        // rebuild the projection from a still-present gLoaded after gState was
+        // reset. See the getLoaded()==null guard in the render sync.
+        clear();
+        projection::disable();
+        refreshModel = true;
+    };
     actions.requestMaterials = [] { requestMaterialList(); };
     actions.beginHotkeyCapture = [](lholo::ui::HotkeyId id) {
         stopHotkeyCapture();


### PR DESCRIPTION
"关闭投影" behaved the same as loading — the projection stayed on screen
and could not be closed.

`closeProjection` ran `disable()` (resets the render state) then `clear()`
(drops the loaded structure) under two different locks. A render frame
landing between them rebuilt the projection from the still-present loaded
structure; because the render state holds its own `shared_ptr`, the later
`clear()` could no longer stop it, so the projection kept rendering as if
freshly loaded.

Changes:
- **Render sync (`Projection.cpp`):** when no structure is loaded but a
  projection is still enabled, tear it down. This guarantees that once the
  loaded structure is cleared, the projection is disabled on the next frame
  — independent of ordering or which thread ran the close.
- **`closeProjection` (`StructureLoader.cpp`):** clear the loaded structure
  before disabling so no frame can rebuild from it, and refresh the menu so
  it reflects the now-unloaded state.

Tested in-game: load → 关闭投影 now removes the projection, the menu shows
unloaded, and reloading works.