### PR TITLE
Handle runtime-state blocks and let manual mode coexist with interaction

### DIFF
--- a/src/place/PlaceHelper.cpp
+++ b/src/place/PlaceHelper.cpp
@@ -92,26 +92,24 @@ constexpr std::uint64_t kSwapRetryMs = 50;
 // changing the player's aim invalidates the cache immediately.
 constexpr int           kRangePlanBudgetPerTick = 16;
 constexpr std::uint64_t kFailedPlanCacheMs      = 250;
-// Manual-mode typematic repeat: after the first block on press, holding pauses
-// for kManualInitialDelayMs and then auto-repeats every kManualRepeatIntervalMs
-// (like keyboard key-repeat), so a tap places one and a hold streams at a steady
-// rate.
+// Manual-mode repeat: after the first block on press, holding pauses for
+// kManualInitialDelayMs and then repeats every kManualRepeatIntervalMs (like
+// keyboard key-repeat), so a tap places one and a hold streams at a steady rate.
 constexpr std::uint64_t kManualInitialDelayMs   = 150;
 constexpr std::uint64_t kManualRepeatIntervalMs = 120;
-// A pending first-block request expires if it cannot be fulfilled this long
-// after the press, so a stale click never places a block later.
+// A pending first-block request expires this long after the press so a stale
+// click never places a block later.
 constexpr std::uint64_t kManualRequestTimeoutMs = 400;
 
 std::atomic_bool gEnabled{false};
 std::atomic_bool gRangeEnabled{false};
-// Manual mode: hold the right mouse button to place, instead of auto-placing.
+// Manual mode: right-click a projection cell to place it (hold to stream).
 std::atomic_bool gManualMode{false};
-// Manual-mode press/hold tracking (typematic repeat). gManualHeld spans the
-// press (startBuildBlock) to the release (stopBuildBlock); the timestamps drive
-// the repeat rate.
+// Manual-mode press/hold tracking. gManualHeld spans the press (startBuildBlock)
+// to the release (stopBuildBlock); the timestamps drive the repeat rate.
 std::atomic_bool     gManualHeld{false};
-// Pending first block of a press; set on press and kept until placed so a quick
-// tap (released before the next game tick) still places one block.
+// Pending first block of a press; set on press over a target and kept until
+// placed so a quick tap still places one block.
 std::atomic_bool     gManualPlaceRequested{false};
 std::atomic_uint64_t gManualPressAt{0};
 std::atomic_uint64_t gLastManualPlaceAt{0};
@@ -220,6 +218,25 @@ struct ItemFind {
     ItemStack const* item;
 };
 
+// Some blocks exist in the world only as a redstone/heat/light-driven runtime
+// state the player can never place directly: a lit redstone lamp/ore, a burning
+// furnace, a powered-off redstone torch, a powered repeater/comparator. Map such
+// a name to the base block that actually gets placed so the inventory lookup, the
+// placement prediction and the correction display all line up. The game restores
+// the lit/powered/heat bit on its own once the block is powered or fuelled.
+std::string_view basePlacedName(std::string_view name) {
+    if (name == "minecraft:lit_redstone_lamp")          return "minecraft:redstone_lamp";
+    if (name == "minecraft:lit_redstone_ore")           return "minecraft:redstone_ore";
+    if (name == "minecraft:lit_deepslate_redstone_ore") return "minecraft:deepslate_redstone_ore";
+    if (name == "minecraft:lit_furnace")                return "minecraft:furnace";
+    if (name == "minecraft:lit_blast_furnace")          return "minecraft:blast_furnace";
+    if (name == "minecraft:lit_smoker")                 return "minecraft:smoker";
+    if (name == "minecraft:unlit_redstone_torch")       return "minecraft:redstone_torch";
+    if (name == "minecraft:powered_repeater")           return "minecraft:unpowered_repeater";
+    if (name == "minecraft:powered_comparator")         return "minecraft:unpowered_comparator";
+    return name;
+}
+
 // Blocks whose placing item has a different name than the block. ItemStack(Block)
 // does not resolve these to the right inventory item (the item was never found),
 // so the item is built from its real name instead.
@@ -234,12 +251,15 @@ char const* placingItemName(std::string const& blockName) {
 }
 
 ItemStack makePlacingItem(Block const& block) {
-    char const* const itemName = placingItemName(block.getTypeName());
+    // Normalize a runtime lit/heat variant to its base block first, then apply
+    // the block->item name remaps (redstone wire/comparator/repeater).
+    std::string const blockName{basePlacedName(block.getTypeName())};
+    char const* const itemName = placingItemName(blockName);
     // Construct the inventory form by item name with neutral aux. Constructing
     // ItemStack directly from an oriented Block copies legacy placement bits
     // (stairs direction/half, pillar axis, ...), but inventory items do not
     // carry those world-state bits and therefore never matched.
-    std::string_view const name = itemName ? std::string_view{itemName} : std::string_view{block.getTypeName()};
+    std::string_view const name = itemName ? std::string_view{itemName} : std::string_view{blockName};
     return ItemStack(name, 1, 0, nullptr);
 }
 
@@ -609,7 +629,7 @@ bool placementPredictionMatches(
     Block const& ghost,
     Block const* expectedDoorUpper = nullptr
 ) {
-    if (predicted.getTypeName() != ghost.getTypeName()) return false;
+    if (basePlacedName(predicted.getTypeName()) != basePlacedName(ghost.getTypeName())) return false;
 
     auto const& name = ghost.getTypeName();
     if (name.ends_with("_stairs")) {
@@ -622,6 +642,15 @@ bool placementPredictionMatches(
     if (!serializedState(ghost, "pillar_axis").empty()) {
         return sameSerializedState(predicted, ghost, "pillar_axis");
     }
+    // Repeaters and comparators: only facing is chosen at placement. The delay
+    // (repeater) and mode (comparator) are set by right-clicking the placed
+    // block, and the powered/output bit is redstone-driven, so none of them can
+    // gate placement. Match on facing alone, for both the powered and unpowered
+    // name variants (the powered ones reach here via basePlacedName above).
+    if (name == "minecraft:unpowered_repeater" || name == "minecraft:powered_repeater"
+        || name == "minecraft:unpowered_comparator" || name == "minecraft:powered_comparator") {
+        return sameSerializedState(predicted, ghost, "minecraft:cardinal_direction");
+    }
     if (expectedDoorUpper) {
         // A door item places both cells. The lower ghost owns direction/open,
         // while the upper ghost owns the hinge. Require the official predictor
@@ -633,6 +662,18 @@ bool placementPredictionMatches(
             && sameSerializedState(predicted, ghost, "open_bit")
             && !expectedHinge.empty()
             && serializedState(predicted, "door_hinge_bit") == expectedHinge;
+    }
+    // A runtime lit/heat variant (lit lamp/ore, burning furnace) is placed as
+    // its base block and switched on by the game afterwards, so the names only
+    // matched after normalization and the runtime id is expected to differ.
+    // Accept on facing where the block is directional (furnaces), otherwise
+    // unconditionally (a plain full block such as a redstone lamp or ore).
+    if (basePlacedName(ghost.getTypeName()) != ghost.getTypeName()) {
+        if (!serializedState(ghost, "facing_direction").empty())
+            return sameSerializedState(predicted, ghost, "facing_direction");
+        if (!serializedState(ghost, "minecraft:cardinal_direction").empty())
+            return sameSerializedState(predicted, ghost, "minecraft:cardinal_direction");
+        return true;
     }
     return predicted.getRuntimeId() == ghost.getRuntimeId();
 }
@@ -840,15 +881,13 @@ void tickEasyPlace() {
     }
 
     // Single-crosshair placement: auto (轻松放置) or manual (手动放置), which are
-    // mutually exclusive in the UI. Manual mode places exactly one block per
-    // right-click press: startBuildBlock sets a one-shot request (consumed by
-    // the placement below); the buildBlock hook cancels the vanilla build so
-    // nothing is placed twice.
+    // mutually exclusive in the UI. Manual mode places on the right button only
+    // when the crosshair is over a projection target (see the build hooks, which
+    // let off-target clicks run vanilla). A tap places one block; holding pauses
+    // for the initial delay and then repeats at a steady rate (typematic).
     if (gManualMode.load(std::memory_order_acquire)) {
         auto const nowManual = GetTickCount64();
         bool allowed = false;
-        // First block of a press: place it even if the button was already
-        // released (a quick tap), until the request goes stale.
         if (gManualPlaceRequested.load(std::memory_order_acquire)) {
             if (nowManual - gManualPressAt.load(std::memory_order_acquire) <= kManualRequestTimeoutMs) {
                 allowed = true;
@@ -856,8 +895,6 @@ void tickEasyPlace() {
                 gManualPlaceRequested.store(false, std::memory_order_release);
             }
         }
-        // While the button stays held, pause for the initial delay and then
-        // repeat at a steady rate (typematic).
         if (!allowed && gManualHeld.load(std::memory_order_acquire)
             && nowManual - gManualPressAt.load(std::memory_order_acquire) >= kManualInitialDelayMs
             && nowManual - gLastManualPlaceAt.load(std::memory_order_acquire) >= kManualRepeatIntervalMs) {
@@ -912,8 +949,8 @@ void tickEasyPlace() {
     player->setSelectedSlot(found.slot);
     if (!placeBlock(*player, placement, found.slot, *found.item)) return;
     markPlaced(placement.cell, now);
-    // Manual repeat bookkeeping: record this placement and mark the current
-    // press as having placed its first block (so holding then auto-repeats).
+    // Manual repeat bookkeeping: consume the one-shot press request and timestamp
+    // this placement so a held button then repeats at a steady rate.
     gLastManualPlaceAt.store(now, std::memory_order_release);
     gManualPlaceRequested.store(false, std::memory_order_release);
 }
@@ -930,20 +967,38 @@ LL_TYPE_INSTANCE_HOOK(
     origin(currentTick);
 }
 
-// Returns true when manual mode is on and `gm` belongs to the local player, i.e.
-// this is the client-side right-click we should take over. The local-player
-// check is essential: the server processes LHolo's own placement through these
-// same functions on the ServerPlayer, and that must not be suppressed.
-bool isLocalManualBuild(GameMode& gm) {
-    if (!gManualMode.load(std::memory_order_acquire)) return false;
+// Returns the local player when manual mode is on and `gm` belongs to it, i.e.
+// this is the client-side right-click we should take over; nullptr otherwise.
+// The local-player check is essential: the server processes LHolo's own
+// placement through these same functions on the ServerPlayer, and that must not
+// be suppressed.
+LocalPlayer* localManualBuildPlayer(GameMode& gm) {
+    if (!gManualMode.load(std::memory_order_acquire)) return nullptr;
     auto client = ll::service::getClientInstance();
     auto* localPlayer = client ? client->getLocalPlayer() : nullptr;
-    return localPlayer && &gm.mPlayer == static_cast<Player*>(localPlayer);
+    if (localPlayer && &gm.mPlayer == static_cast<Player*>(localPlayer)) return localPlayer;
+    return nullptr;
 }
 
-// Manual-mode press edge: the initial right-click. Begin a held sequence (first
-// block placed immediately by tickEasyPlace, then typematic repeat) and cancel
-// the vanilla build start so nothing is placed twice.
+// Fresh, synchronous check of whether the crosshair is over a placeable missing
+// projection cell. The build hooks call this at click time so the decision never
+// lags a game tick behind (a stale check let vanilla place a stray block when
+// the crosshair had just moved onto a projected cell).
+bool crosshairOverManualTarget(LocalPlayer& player) {
+    Vec3 const eye = player.getEyePos();
+    Vec3 const rawDir = player.getViewVector(1.0f);
+    float const length = std::sqrt(rawDir.x * rawDir.x + rawDir.y * rawDir.y + rawDir.z * rawDir.z);
+    if (length <= 0.0f) return false;
+    Vec3 const dir{rawDir.x / length, rawDir.y / length, rawDir.z / length};
+    auto const target = findProjectionTarget(player, eye, dir, player.getPickRange());
+    return target && findItemSlot(player, *target->block).slot >= 0;
+}
+
+// Manual-mode press edge: begin a held sequence and, when the crosshair is over
+// a projection target, request the first block and cancel the vanilla build so
+// LHolo (which auto-selects the right item) places it. Off-target the press runs
+// vanilla so a tap can still open a chest, change a repeater's delay or place
+// scaffolding.
 LL_TYPE_INSTANCE_HOOK(
     GameModeStartBuildHook,
     ll::memory::HookPriority::Normal,
@@ -953,16 +1008,18 @@ LL_TYPE_INSTANCE_HOOK(
     ::BlockPos const& pos,
     uchar             face
 ) {
-    if (isLocalManualBuild(*this)) {
+    if (auto* player = localManualBuildPlayer(*this)) {
         gManualPressAt.store(GetTickCount64(), std::memory_order_release);
-        gManualPlaceRequested.store(true, std::memory_order_release);
         gManualHeld.store(true, std::memory_order_release);
-        return;  // LHolo handles the placement from tickEasyPlace.
+        if (crosshairOverManualTarget(*player)) {
+            gManualPlaceRequested.store(true, std::memory_order_release);
+            return;  // LHolo handles the placement from tickEasyPlace.
+        }
     }
     origin(pos, face);
 }
 
-// Manual-mode release edge: stop the typematic repeat when the button is let go.
+// Manual-mode release edge: stop the repeat when the button is let go.
 LL_TYPE_INSTANCE_HOOK(
     GameModeStopBuildHook,
     ll::memory::HookPriority::Normal,
@@ -970,15 +1027,17 @@ LL_TYPE_INSTANCE_HOOK(
     &GameMode::$stopBuildBlock,
     void
 ) {
-    if (isLocalManualBuild(*this)) {
+    if (localManualBuildPlayer(*this)) {
         gManualHeld.store(false, std::memory_order_release);
-        return;
     }
     origin();
 }
 
-// Suppress the vanilla continuous build while the button is held in manual mode;
-// LHolo drives placement from the press/hold state above.
+// GameMode::buildBlock is the shared right-click entry for interacting with a
+// block (chest, repeater, ...) AND for placing one, so it must NOT be cancelled
+// outright — that would disable right-click entirely in manual mode. Suppress
+// the vanilla build only while the crosshair is over a projection target, where
+// LHolo is placing; off-target clicks fall through to vanilla.
 LL_TYPE_INSTANCE_HOOK(
     GameModeBuildBlockHook,
     ll::memory::HookPriority::Normal,
@@ -989,7 +1048,9 @@ LL_TYPE_INSTANCE_HOOK(
     uchar             face,
     bool const        isSimTick
 ) {
-    if (isLocalManualBuild(*this)) return false;
+    if (auto* player = localManualBuildPlayer(*this); player && crosshairOverManualTarget(*player)) {
+        return false;
+    }
     return origin(pos, face, isSimTick);
 }
 
@@ -1030,9 +1091,10 @@ int getPlacementRadius() {
 }
 
 void setManualMode(bool manual) {
+    logger().info("Manual placement {}", manual ? "enabled" : "disabled");
     if (!manual) {
         // A release hook can be missed while menus or mode switches are active.
-        // Never carry a stale press/hold request into the next manual session.
+        // Never carry a stale press/hold state into the next manual session.
         gManualHeld.store(false, std::memory_order_release);
         gManualPlaceRequested.store(false, std::memory_order_release);
         gManualPressAt.store(0, std::memory_order_release);

--- a/src/projection/Projection.cpp
+++ b/src/projection/Projection.cpp
@@ -773,8 +773,30 @@ Block const* transformExpectedBlock(
     return &LegacyStructureTemplate::_mapToData(*block, settings);
 }
 
+// Maps a game-driven runtime variant (lit_redstone_lamp, powered_repeater, ...)
+// to the base block a player actually places. Used only by the WrongType check
+// so a same-base block in a different runtime state is treated as a WrongState
+// (orange) rather than a WrongType (red); projectionStatesMatch still compares
+// the runtime state strictly so the mismatch is surfaced.
+std::string_view basePlacedName(std::string_view name) {
+    if (name == "minecraft:lit_redstone_lamp")          return "minecraft:redstone_lamp";
+    if (name == "minecraft:lit_redstone_ore")           return "minecraft:redstone_ore";
+    if (name == "minecraft:lit_deepslate_redstone_ore") return "minecraft:deepslate_redstone_ore";
+    if (name == "minecraft:lit_furnace")                return "minecraft:furnace";
+    if (name == "minecraft:lit_blast_furnace")          return "minecraft:blast_furnace";
+    if (name == "minecraft:lit_smoker")                 return "minecraft:smoker";
+    if (name == "minecraft:unlit_redstone_torch")       return "minecraft:redstone_torch";
+    if (name == "minecraft:powered_repeater")           return "minecraft:unpowered_repeater";
+    if (name == "minecraft:powered_comparator")         return "minecraft:unpowered_comparator";
+    return name;
+}
+
 bool projectionStatesMatch(Block const& expected, Block const& actual) {
     if (expected == actual) return true;
+    // Runtime lit/powered state must match exactly here: a lit-lamp projection is
+    // only satisfied by a lit lamp, an off projection by an off block. The base
+    // normalization is intentionally NOT applied so the mismatch surfaces (as a
+    // WrongState, kept out of WrongType by the base compare in the caller).
     if (expected.getTypeName() != actual.getTypeName()) return false;
 
     auto stateMatches = [&](auto const& state) {
@@ -1139,7 +1161,8 @@ void renderProjection(BaseActorRenderContext& renderContext, bool renderAlphaLay
             auto const bodyMissing = expected && actual.isAir();
             auto const liquidMissing = expectedLiquid && actualLiquid.isAir();
             auto const bodyTypeWrong = expected
-                && !actual.isAir() && actual.getTypeName() != expected->getTypeName();
+                && !actual.isAir()
+                && basePlacedName(actual.getTypeName()) != basePlacedName(expected->getTypeName());
             auto const liquidTypeWrong = expectedLiquid
                 && !actualLiquid.isAir() && actualLiquid.getTypeName() != expectedLiquid->getTypeName();
             auto const liquidCellOccupiedBySolid = !expected && expectedLiquid && !actual.isAir()

--- a/src/structure/StructureLoader.cpp
+++ b/src/structure/StructureLoader.cpp
@@ -119,6 +119,10 @@ std::atomic_bool                 gCapturingLayerIncreaseHotkey{false};
 std::atomic_bool                 gCapturingLayerDecreaseHotkey{false};
 std::atomic_bool                 gLayerIncreaseHotkeyHeld{false};
 std::atomic_bool                 gLayerDecreaseHotkeyHeld{false};
+std::atomic_uint                 gToggleManualHotkey{'R'};
+std::atomic_uint                 gToggleManualHotkeyModifiers{0};
+std::atomic_bool                 gCapturingToggleManualHotkey{false};
+std::atomic_bool                 gToggleManualHotkeyHeld{false};
 std::array<std::atomic_uint, 6>  gMoveHotkeys{VK_LEFT, VK_RIGHT, VK_UP, VK_DOWN, VK_UP, VK_DOWN};
 std::array<std::atomic_uint, 6>  gMoveHotkeyModifiers{
     kHotkeyModifierControl,
@@ -138,6 +142,7 @@ std::atomic_int                  gPendingOffsetX{0};
 std::atomic_int                  gPendingOffsetY{0};
 std::atomic_int                  gPendingOffsetZ{0};
 std::atomic_int                  gPendingLayerDelta{0};
+std::atomic_bool                 gPendingToggleManual{false};
 std::atomic_bool                 gPendingSettingsSave{false};
 std::atomic_uint64_t             gIgnoreHotkeyUntil{0};
 std::atomic_bool                 gHasSavedProjection{false};
@@ -1058,6 +1063,9 @@ bool handleGuiHotkeyKeyDown(unsigned int virtualKey) {
     } else if (gCapturingLayerDecreaseHotkey.load(std::memory_order_acquire)) {
         captureKey = &gLayerDecreaseHotkey;
         captureModifiers = &gLayerDecreaseHotkeyModifiers;
+    } else if (gCapturingToggleManualHotkey.load(std::memory_order_acquire)) {
+        captureKey = &gToggleManualHotkey;
+        captureModifiers = &gToggleManualHotkeyModifiers;
     } else {
         for (std::size_t index = 0; index < gCapturingMoveHotkey.size(); ++index) {
             if (gCapturingMoveHotkey[index].load(std::memory_order_acquire)) {
@@ -1075,6 +1083,7 @@ bool handleGuiHotkeyKeyDown(unsigned int virtualKey) {
             gCapturingGuiHotkey.store(false, std::memory_order_release);
             gCapturingLayerIncreaseHotkey.store(false, std::memory_order_release);
             gCapturingLayerDecreaseHotkey.store(false, std::memory_order_release);
+            gCapturingToggleManualHotkey.store(false, std::memory_order_release);
             for (auto& capturing : gCapturingMoveHotkey) {
                 capturing.store(false, std::memory_order_release);
             }
@@ -1102,6 +1111,7 @@ bool handleGuiHotkeyKeyDown(unsigned int virtualKey) {
             clearDuplicate(gGuiHotkey, gGuiHotkeyModifiers);
             clearDuplicate(gLayerIncreaseHotkey, gLayerIncreaseHotkeyModifiers);
             clearDuplicate(gLayerDecreaseHotkey, gLayerDecreaseHotkeyModifiers);
+            clearDuplicate(gToggleManualHotkey, gToggleManualHotkeyModifiers);
             for (std::size_t index = 0; index < gMoveHotkeys.size(); ++index) {
                 clearDuplicate(gMoveHotkeys[index], gMoveHotkeyModifiers[index]);
             }
@@ -1167,6 +1177,15 @@ bool handleGuiHotkeyKeyDown(unsigned int virtualKey) {
         }
         return true;
     }
+    auto const toggleManualHotkey = gToggleManualHotkey.load(std::memory_order_acquire);
+    if (toggleManualHotkey != 0 && virtualKey == toggleManualHotkey
+        && modifiers == gToggleManualHotkeyModifiers.load(std::memory_order_acquire)) {
+        if (GetTickCount64() >= gIgnoreHotkeyUntil.load(std::memory_order_acquire)
+            && !gToggleManualHotkeyHeld.exchange(true, std::memory_order_acq_rel)) {
+            gPendingToggleManual.store(true, std::memory_order_release);
+        }
+        return true;
+    }
     return false;
 }
 
@@ -1194,6 +1213,9 @@ bool handleGuiHotkeyKeyUp(unsigned int virtualKey) {
     if (virtualKey == gLayerDecreaseHotkey.load(std::memory_order_acquire)) {
         consumed = gLayerDecreaseHotkeyHeld.exchange(false, std::memory_order_acq_rel) || consumed;
     }
+    if (virtualKey == gToggleManualHotkey.load(std::memory_order_acquire)) {
+        consumed = gToggleManualHotkeyHeld.exchange(false, std::memory_order_acq_rel) || consumed;
+    }
     for (std::size_t index = 0; index < gMoveHotkeys.size(); ++index) {
         if (virtualKey == gMoveHotkeys[index].load(std::memory_order_acquire)) {
             consumed = gMoveHotkeyHeld[index].exchange(false, std::memory_order_acq_rel) || consumed;
@@ -1218,6 +1240,7 @@ void resetHotkeyState() {
     gGuiHotkeyHeld.store(false, std::memory_order_release);
     gLayerIncreaseHotkeyHeld.store(false, std::memory_order_release);
     gLayerDecreaseHotkeyHeld.store(false, std::memory_order_release);
+    gToggleManualHotkeyHeld.store(false, std::memory_order_release);
     for (auto& held : gMoveHotkeyHeld) held.store(false, std::memory_order_release);
     for (auto& deadline : gConsumeKeyReleaseUntil) deadline.store(0, std::memory_order_release);
 }
@@ -1255,6 +1278,17 @@ void processPendingHotkeyActions() {
         auto const current = static_cast<long long>(gDisplayLayer.load(std::memory_order_relaxed));
         auto const next = std::clamp(current + static_cast<long long>(layerDelta), 0LL, static_cast<long long>(maxLayer));
         gDisplayLayer.store(static_cast<int>(next), std::memory_order_relaxed);
+    }
+
+    if (gPendingToggleManual.exchange(false, std::memory_order_acq_rel)) {
+        bool const enable = !place::isManualMode();
+        place::setManualMode(enable);
+        // Manual, easy and range placement are mutually exclusive (as in the UI).
+        if (enable) {
+            place::setEnabled(false);
+            place::setRangeEnabled(false);
+        }
+        changed = true;
     }
 
     changed = gPendingSettingsSave.exchange(false, std::memory_order_acq_rel) || changed;
@@ -1426,6 +1460,7 @@ UiHotkeyBinding hotkeyBinding(lholo::ui::HotkeyId id) {
     case lholo::ui::HotkeyId::MoveYMinus: return {&gMoveHotkeys[5], &gMoveHotkeyModifiers[5], &gCapturingMoveHotkey[5]};
     case lholo::ui::HotkeyId::LayerIncrease: return {&gLayerIncreaseHotkey, &gLayerIncreaseHotkeyModifiers, &gCapturingLayerIncreaseHotkey};
     case lholo::ui::HotkeyId::LayerDecrease: return {&gLayerDecreaseHotkey, &gLayerDecreaseHotkeyModifiers, &gCapturingLayerDecreaseHotkey};
+    case lholo::ui::HotkeyId::ToggleManual: return {&gToggleManualHotkey, &gToggleManualHotkeyModifiers, &gCapturingToggleManualHotkey};
     }
     return {};
 }
@@ -1434,11 +1469,12 @@ void stopHotkeyCapture() {
     gCapturingGuiHotkey.store(false, std::memory_order_release);
     gCapturingLayerIncreaseHotkey.store(false, std::memory_order_release);
     gCapturingLayerDecreaseHotkey.store(false, std::memory_order_release);
+    gCapturingToggleManualHotkey.store(false, std::memory_order_release);
     for (auto& capturing : gCapturingMoveHotkey) capturing.store(false, std::memory_order_release);
 }
 
 struct HotkeyDefinition { lholo::ui::HotkeyId id; char const* label; };
-constexpr std::array<HotkeyDefinition, 9> kHotkeyDefinitions{{
+constexpr std::array<HotkeyDefinition, 10> kHotkeyDefinitions{{
     {lholo::ui::HotkeyId::Gui, "打开投影菜单"},
     {lholo::ui::HotkeyId::MoveXMinus, "结构偏移 X -1"},
     {lholo::ui::HotkeyId::MoveXPlus, "结构偏移 X +1"},
@@ -1447,7 +1483,8 @@ constexpr std::array<HotkeyDefinition, 9> kHotkeyDefinitions{{
     {lholo::ui::HotkeyId::MoveYPlus, "结构偏移 Y +1"},
     {lholo::ui::HotkeyId::MoveYMinus, "结构偏移 Y -1"},
     {lholo::ui::HotkeyId::LayerIncrease, "上一层"},
-    {lholo::ui::HotkeyId::LayerDecrease, "下一层"}
+    {lholo::ui::HotkeyId::LayerDecrease, "下一层"},
+    {lholo::ui::HotkeyId::ToggleManual, "开关手动放置"}
 }};
 
 lholo::ui::MenuModel makeMenuModel(float effectiveUiScale) {
@@ -1706,6 +1743,8 @@ lholo::ui::MenuActions makeMenuActions(bool& refreshModel) {
         gLayerDecreaseHotkey.store(VK_DOWN, std::memory_order_relaxed);
         gLayerIncreaseHotkeyModifiers.store(kHotkeyModifierAlt, std::memory_order_relaxed);
         gLayerDecreaseHotkeyModifiers.store(kHotkeyModifierAlt, std::memory_order_relaxed);
+        gToggleManualHotkey.store('R', std::memory_order_relaxed);
+        gToggleManualHotkeyModifiers.store(0, std::memory_order_relaxed);
         stopHotkeyCapture();
         resetHotkeyState();
         saveSettings();
@@ -1835,6 +1874,14 @@ void loadSettings() {
             std::clamp(json.value("layerDecreaseHotkeyModifiers", static_cast<int>(kHotkeyModifierAlt)), 0, 7),
             std::memory_order_relaxed
         );
+        gToggleManualHotkey.store(
+            std::clamp(json.value("toggleManualHotkey", static_cast<int>('R')), 0, 255),
+            std::memory_order_relaxed
+        );
+        gToggleManualHotkeyModifiers.store(
+            std::clamp(json.value("toggleManualHotkeyModifiers", 0), 0, 7),
+            std::memory_order_relaxed
+        );
         static char const* moveKeyNames[]{
             "moveXMinusHotkey",
             "moveXPlusHotkey",
@@ -1948,6 +1995,8 @@ void saveSettings() {
             {"layerDecreaseHotkey", gLayerDecreaseHotkey.load(std::memory_order_relaxed)},
             {"layerIncreaseHotkeyModifiers", gLayerIncreaseHotkeyModifiers.load(std::memory_order_relaxed)},
             {"layerDecreaseHotkeyModifiers", gLayerDecreaseHotkeyModifiers.load(std::memory_order_relaxed)},
+            {"toggleManualHotkey", gToggleManualHotkey.load(std::memory_order_relaxed)},
+            {"toggleManualHotkeyModifiers", gToggleManualHotkeyModifiers.load(std::memory_order_relaxed)},
             {"moveXMinusHotkey", gMoveHotkeys[0].load(std::memory_order_relaxed)},
             {"moveXPlusHotkey", gMoveHotkeys[1].load(std::memory_order_relaxed)},
             {"moveZMinusHotkey", gMoveHotkeys[2].load(std::memory_order_relaxed)},

--- a/src/ui/LHoloMenu.h
+++ b/src/ui/LHoloMenu.h
@@ -43,7 +43,7 @@ struct CaptureDraftModel {
 
 enum class HotkeyId : std::uint8_t {
     Gui, MoveXMinus, MoveXPlus, MoveZMinus, MoveZPlus,
-    MoveYPlus, MoveYMinus, LayerIncrease, LayerDecrease
+    MoveYPlus, MoveYMinus, LayerIncrease, LayerDecrease, ToggleManual
 };
 
 struct HotkeyRow {
@@ -97,7 +97,7 @@ struct MenuModel {
     int maxLayerY{};
     int maxLayerX{};
 
-    std::array<HotkeyRow, 9> hotkeys{};
+    std::array<HotkeyRow, 10> hotkeys{};
     bool hudEnabled{true};
     int hudPosition{1};
     bool hudShowFileName{true};


### PR DESCRIPTION
### Runtime-state blocks (lit lamp/ore, burning furnace, powered repeater/comparator, off redstone torch)
These exist in the world only as a game-driven variant a player can never place directly, so easy/manual place gave up on them (the item lookup and the placement predictor keyed on the exact block name) and the overlay flagged a correctly placed base block as wrong.

- Add `basePlacedName()` (in the placer and the projection) mapping each runtime variant to the base block that is actually placed.
- **Placement**: resolve the inventory item and accept the predicted placement through the base name. Repeaters/comparators verify **facing only** — delay/mode are set after placement, the powered bit is redstone-driven — which also fixes placing a delay-adjusted repeater.
- **Correction display**: the runtime state stays strict (a lit-lamp projection is only satisfied by a lit lamp), but a same-base different-state block is a `WrongState` (orange), not a `WrongType` (red).

### Manual placement coexists with interaction
`GameMode::buildBlock` is the shared right-click entry for interacting AND placing, so cancelling it whenever manual mode was on disabled right-click entirely (no opening chests, changing repeater ticks, or placing scaffolding).

- Manual mode now takes the right button over **only while the crosshair is over a placeable projection cell**, checked synchronously at click time so vanilla never slips in a stray block; off-target clicks fall through to vanilla.
- A tap places one block (auto-selecting the item); holding streams.

### Toggle hotkey
Add a rebindable hotkey (default **R**) that toggles manual placement in-game.

Tested in-game on litematic structures. (One minor click-timing edge remains but is usable.)