### PR TITLE
添加“快捷结构偏移”，添加偏移预览

### DIFF
--- a/src/input/HotkeyTypes.h
+++ b/src/input/HotkeyTypes.h
@@ -10,27 +10,29 @@ namespace lholo::input {
 // lookup derives its size or index from this enum so adding a slot cannot
 // silently desynchronize input handling, settings, and menu presentation.
 enum class HotkeyId : std::uint8_t {
-    Gui,
-    MoveXMinus,
-    MoveXPlus,
-    MoveZMinus,
-    MoveZPlus,
-    MoveYPlus,
-    MoveYMinus,
-    LayerIncrease,
-    LayerDecrease,
-    LoadProjection,
-    CloseProjection,
-    Count
+  Gui,
+  StructureOffset,
+  MoveXMinus,
+  MoveXPlus,
+  MoveZMinus,
+  MoveZPlus,
+  MoveYPlus,
+  MoveYMinus,
+  LayerIncrease,
+  LayerDecrease,
+  LoadProjection,
+  CloseProjection,
+  Count
 };
 
 [[nodiscard]] constexpr std::size_t hotkeyIndex(HotkeyId id) noexcept {
-    return static_cast<std::size_t>(id);
+  return static_cast<std::size_t>(id);
 }
 
 inline constexpr std::size_t kHotkeyCount = hotkeyIndex(HotkeyId::Count);
-inline constexpr std::size_t kMoveHotkeyFirst = hotkeyIndex(HotkeyId::MoveXMinus);
-inline constexpr std::size_t kMoveHotkeyCount
-    = hotkeyIndex(HotkeyId::MoveYMinus) - kMoveHotkeyFirst + 1;
+inline constexpr std::size_t kMoveHotkeyFirst =
+    hotkeyIndex(HotkeyId::MoveXMinus);
+inline constexpr std::size_t kMoveHotkeyCount =
+    hotkeyIndex(HotkeyId::MoveYMinus) - kMoveHotkeyFirst + 1;
 
 } // namespace lholo::input

--- a/src/overlay/ImGuiOverlay.cpp
+++ b/src/overlay/ImGuiOverlay.cpp
@@ -34,68 +34,67 @@
 #include <backends/imgui_impl_win32.h>
 #include <imgui.h>
 
-#include <atomic>
 #include <array>
+#include <atomic>
 #include <cfloat>
 #include <filesystem>
 #include <mutex>
 
+
 #include "input/MenuInputGuard.h"
+#include "ll/api/mod/NativeMod.h"
 #include "plugin/LHolo.h"
 #include "structure/StructureLoader.h"
 #include "ui/FluentTheme.h"
-#include "ll/api/mod/NativeMod.h"
 
-extern IMGUI_IMPL_API LRESULT ImGui_ImplWin32_WndProcHandler(HWND, UINT, WPARAM, LPARAM);
+
+extern IMGUI_IMPL_API LRESULT ImGui_ImplWin32_WndProcHandler(HWND, UINT, WPARAM,
+                                                             LPARAM);
 
 namespace lholo::overlay {
 namespace {
 
-using PresentFn = HRESULT(__stdcall*)(IDXGISwapChain*, UINT, UINT);
-using Present1Fn = HRESULT(__stdcall*)(IDXGISwapChain1*, UINT, UINT, DXGI_PRESENT_PARAMETERS const*);
-using ResizeBuffersFn = HRESULT(__stdcall*)(IDXGISwapChain*, UINT, UINT, UINT, DXGI_FORMAT, UINT);
-using ResizeBuffers1Fn = HRESULT(__stdcall*)(
-    IDXGISwapChain3*,
-    UINT,
-    UINT,
-    UINT,
-    DXGI_FORMAT,
-    UINT,
-    UINT const*,
-    IUnknown* const*
-);
-using ExecuteCommandListsFn = void(__stdcall*)(ID3D12CommandQueue*, UINT, ID3D12CommandList* const*);
+using PresentFn = HRESULT(__stdcall *)(IDXGISwapChain *, UINT, UINT);
+using Present1Fn = HRESULT(__stdcall *)(IDXGISwapChain1 *, UINT, UINT,
+                                        DXGI_PRESENT_PARAMETERS const *);
+using ResizeBuffersFn = HRESULT(__stdcall *)(IDXGISwapChain *, UINT, UINT, UINT,
+                                             DXGI_FORMAT, UINT);
+using ResizeBuffers1Fn = HRESULT(__stdcall *)(IDXGISwapChain3 *, UINT, UINT,
+                                              UINT, DXGI_FORMAT, UINT,
+                                              UINT const *, IUnknown *const *);
+using ExecuteCommandListsFn = void(__stdcall *)(ID3D12CommandQueue *, UINT,
+                                                ID3D12CommandList *const *);
 
-PresentFn             gOriginalPresent{};
-Present1Fn            gOriginalPresent1{};
-ResizeBuffersFn       gOriginalResizeBuffers{};
-ResizeBuffers1Fn      gOriginalResizeBuffers1{};
+PresentFn gOriginalPresent{};
+Present1Fn gOriginalPresent1{};
+ResizeBuffersFn gOriginalResizeBuffers{};
+ResizeBuffers1Fn gOriginalResizeBuffers1{};
 ExecuteCommandListsFn gOriginalExecuteCommandLists{};
 
-void* gPresentTarget{};
-void* gPresent1Target{};
-void* gResizeTarget{};
-void* gResize1Target{};
-void* gExecuteTarget{};
+void *gPresentTarget{};
+void *gPresent1Target{};
+void *gResizeTarget{};
+void *gResize1Target{};
+void *gExecuteTarget{};
 
-ID3D11Device*        gDevice{};
-ID3D11DeviceContext* gDeviceContext{};
-ID3D11On12Device*    gDevice11On12{};
-ID3D12CommandQueue*  gGameQueue{};
+ID3D11Device *gDevice{};
+ID3D11DeviceContext *gDeviceContext{};
+ID3D11On12Device *gDevice11On12{};
+ID3D12CommandQueue *gGameQueue{};
 // Weak identity of the swap chain currently owned by LHolo. Access is guarded
 // by gResourceMutex; retaining it avoids extending the game's COM lifetime.
-IDXGISwapChain*      gActiveSwapChain{};
+IDXGISwapChain *gActiveSwapChain{};
 
-HWND    gWindow{};
+HWND gWindow{};
 WNDPROC gOriginalWndProc{};
 std::atomic_bool gInstalled{false};
 std::atomic_bool gShuttingDown{false};
 std::atomic_bool gRendering{false};
 std::atomic_ullong gGraphicsResumeAt{};
-std::mutex       gResourceMutex;
-bool             gImGuiInitialized{};
-bool             gGraphicsInitialized{};
-bool             gGuiVisibleLastFrame{};
+std::mutex gResourceMutex;
+bool gImGuiInitialized{};
+bool gGraphicsInitialized{};
+bool gGuiVisibleLastFrame{};
 std::atomic_bool gMouseHandoffActive{};
 // ImGui's Win32 backend sets the native cursor handle to null while drawing
 // its software cursor. LHolo can skip NewFrame entirely after the menu closes,
@@ -103,805 +102,855 @@ std::atomic_bool gMouseHandoffActive{};
 // ShowCursor display counter owned by Minecraft.
 constexpr UINT kMsgRestoreNativeCursor = WM_APP + 0x101;
 std::array<bool, 256> gGameKeysDown{};
-std::array<bool, 5>   gGameMouseButtonsDown{};
-std::atomic_bool      gConsumeEscapeRelease{false};
+std::array<bool, 5> gGameMouseButtonsDown{};
+std::atomic_bool gConsumeEscapeRelease{false};
 
 constexpr ULONGLONG kFullscreenGraphicsResumeDelayMs = 750;
-constexpr ULONGLONG kResizeGraphicsResumeDelayMs     = 100;
-constexpr size_t    kPresentVtableIndex              = 8;
-constexpr size_t    kResizeBuffersVtableIndex        = 13;
-constexpr size_t    kPresent1VtableIndex             = 22;
-constexpr size_t    kResizeBuffers1VtableIndex       = 39;
-constexpr size_t    kExecuteCommandListsVtableIndex  = 10;
+constexpr ULONGLONG kResizeGraphicsResumeDelayMs = 100;
+constexpr size_t kPresentVtableIndex = 8;
+constexpr size_t kResizeBuffersVtableIndex = 13;
+constexpr size_t kPresent1VtableIndex = 22;
+constexpr size_t kResizeBuffers1VtableIndex = 39;
+constexpr size_t kExecuteCommandListsVtableIndex = 10;
 
-auto& logger() { return LHolo::getInstance().getSelf().getLogger(); }
+auto &logger() { return LHolo::getInstance().getSelf().getLogger(); }
 
-void logGraphicsFailure(IDXGISwapChain* swapChain, char const* operation, HRESULT result) {
-    HRESULT removedReason = S_OK;
-    ID3D12Device* device12{};
-    if (swapChain && SUCCEEDED(swapChain->GetDevice(
-            __uuidof(ID3D12Device),
-            reinterpret_cast<void**>(&device12)
-        ))) {
-        removedReason = device12->GetDeviceRemovedReason();
-        device12->Release();
-    }
-    logger().error(
-        "ImGui graphics call {} failed: HRESULT=0x{:08X}, deviceRemovedReason=0x{:08X}",
-        operation,
-        static_cast<unsigned int>(result),
-        static_cast<unsigned int>(removedReason)
-    );
+void logGraphicsFailure(IDXGISwapChain *swapChain, char const *operation,
+                        HRESULT result) {
+  HRESULT removedReason = S_OK;
+  ID3D12Device *device12{};
+  if (swapChain &&
+      SUCCEEDED(swapChain->GetDevice(__uuidof(ID3D12Device),
+                                     reinterpret_cast<void **>(&device12)))) {
+    removedReason = device12->GetDeviceRemovedReason();
+    device12->Release();
+  }
+  logger().error("ImGui graphics call {} failed: HRESULT=0x{:08X}, "
+                 "deviceRemovedReason=0x{:08X}",
+                 operation, static_cast<unsigned int>(result),
+                 static_cast<unsigned int>(removedReason));
 }
 
 HWND findProcessWindow() {
-    struct Search { DWORD pid; HWND result; } search{GetCurrentProcessId(), nullptr};
-    EnumWindows(
-        [](HWND window, LPARAM parameter) -> BOOL {
-            auto& state = *reinterpret_cast<Search*>(parameter);
-            DWORD pid{};
-            GetWindowThreadProcessId(window, &pid);
-            if (pid == state.pid && IsWindowVisible(window) && GetWindow(window, GW_OWNER) == nullptr) {
-                state.result = window;
-                return FALSE;
-            }
-            return TRUE;
-        },
-        reinterpret_cast<LPARAM>(&search)
-    );
-    return search.result;
+  struct Search {
+    DWORD pid;
+    HWND result;
+  } search{GetCurrentProcessId(), nullptr};
+  EnumWindows(
+      [](HWND window, LPARAM parameter) -> BOOL {
+        auto &state = *reinterpret_cast<Search *>(parameter);
+        DWORD pid{};
+        GetWindowThreadProcessId(window, &pid);
+        if (pid == state.pid && IsWindowVisible(window) &&
+            GetWindow(window, GW_OWNER) == nullptr) {
+          state.result = window;
+          return FALSE;
+        }
+        return TRUE;
+      },
+      reinterpret_cast<LPARAM>(&search));
+  return search.result;
 }
 
 void releaseGraphicsBackend() {
-    if (gGraphicsInitialized) {
-        ImGui_ImplDX11_Shutdown();
-        gGraphicsInitialized = false;
-    }
-    if (gDeviceContext) {
-        ID3D11RenderTargetView* empty{};
-        gDeviceContext->OMSetRenderTargets(1, &empty, nullptr);
-        gDeviceContext->ClearState();
-        gDeviceContext->Flush();
-    }
-    if (gDevice11On12) gDevice11On12->Release();
-    if (gDeviceContext) gDeviceContext->Release();
-    if (gDevice) gDevice->Release();
-    gDevice11On12 = nullptr;
-    gDeviceContext = nullptr;
-    gDevice = nullptr;
+  if (gGraphicsInitialized) {
+    ImGui_ImplDX11_Shutdown();
+    gGraphicsInitialized = false;
+  }
+  if (gDeviceContext) {
+    ID3D11RenderTargetView *empty{};
+    gDeviceContext->OMSetRenderTargets(1, &empty, nullptr);
+    gDeviceContext->ClearState();
+    gDeviceContext->Flush();
+  }
+  if (gDevice11On12)
+    gDevice11On12->Release();
+  if (gDeviceContext)
+    gDeviceContext->Release();
+  if (gDevice)
+    gDevice->Release();
+  gDevice11On12 = nullptr;
+  gDeviceContext = nullptr;
+  gDevice = nullptr;
 }
 
-bool canUseSwapChainLocked(IDXGISwapChain* swapChain) {
-    if (!swapChain) return false;
-    if (!gActiveSwapChain || gActiveSwapChain == swapChain) return true;
-    if (gGraphicsInitialized || !gWindow) return false;
+bool canUseSwapChainLocked(IDXGISwapChain *swapChain) {
+  if (!swapChain)
+    return false;
+  if (!gActiveSwapChain || gActiveSwapChain == swapChain)
+    return true;
+  if (gGraphicsInitialized || !gWindow)
+    return false;
 
-    // A fullscreen/device transition may replace the swap-chain object while
-    // retaining the game window. Permit that explicit handoff, but never let
-    // a composition/off-screen chain from another mod claim the overlay.
-    DXGI_SWAP_CHAIN_DESC description{};
-    return SUCCEEDED(swapChain->GetDesc(&description))
-        && description.OutputWindow == gWindow;
+  // A fullscreen/device transition may replace the swap-chain object while
+  // retaining the game window. Permit that explicit handoff, but never let
+  // a composition/off-screen chain from another mod claim the overlay.
+  DXGI_SWAP_CHAIN_DESC description{};
+  return SUCCEEDED(swapChain->GetDesc(&description)) &&
+         description.OutputWindow == gWindow;
 }
 
 // Callers must hold gResourceMutex across both helpers and the original DXGI
 // resize call so Present cannot rebuild against a swap chain mid-transition.
 void prepareForSwapChainResizeLocked() {
-    if (gGraphicsInitialized) releaseGraphicsBackend();
+  if (gGraphicsInitialized)
+    releaseGraphicsBackend();
 }
 
 void deferGraphicsResumeAfterSwapChainResizeLocked() {
-    // Window-edge dragging can issue a burst of resizes. Debounce backend
-    // recreation and let the first stable Present rebuild it lazily. Never
-    // shorten the longer suspension already scheduled by an F11 transition.
-    auto const resizeResumeAt = GetTickCount64() + kResizeGraphicsResumeDelayMs;
-    auto const currentResumeAt = gGraphicsResumeAt.load(std::memory_order_acquire);
-    if (currentResumeAt < resizeResumeAt) {
-        gGraphicsResumeAt.store(resizeResumeAt, std::memory_order_release);
-    }
+  // Window-edge dragging can issue a burst of resizes. Debounce backend
+  // recreation and let the first stable Present rebuild it lazily. Never
+  // shorten the longer suspension already scheduled by an F11 transition.
+  auto const resizeResumeAt = GetTickCount64() + kResizeGraphicsResumeDelayMs;
+  auto const currentResumeAt =
+      gGraphicsResumeAt.load(std::memory_order_acquire);
+  if (currentResumeAt < resizeResumeAt) {
+    gGraphicsResumeAt.store(resizeResumeAt, std::memory_order_release);
+  }
 }
 
 void loadFonts() {
-    auto& io = ImGui::GetIO();
-    ImFontConfig config{};
-    config.OversampleH = 2;
-    config.OversampleV = 2;
-    auto const chineseFont = "C:\\Windows\\Fonts\\msyh.ttc";
-    if (std::filesystem::exists(chineseFont)) {
-        // Build the atlas at 2x the logical base size. A 4K/default 2x UI can
-        // then render at native font resolution instead of magnifying an 18px
-        // atlas, which made text and navigation edges look pixelated.
-        io.Fonts->AddFontFromFileTTF(
-            chineseFont,
-            36.0f,
-            &config,
-            io.Fonts->GetGlyphRangesChineseFull()
-        );
-    } else {
-        io.Fonts->AddFontDefault();
-    }
+  auto &io = ImGui::GetIO();
+  ImFontConfig config{};
+  config.OversampleH = 2;
+  config.OversampleV = 2;
+  auto const chineseFont = "C:\\Windows\\Fonts\\msyh.ttc";
+  if (std::filesystem::exists(chineseFont)) {
+    // Build the atlas at 2x the logical base size. A 4K/default 2x UI can
+    // then render at native font resolution instead of magnifying an 18px
+    // atlas, which made text and navigation edges look pixelated.
+    io.Fonts->AddFontFromFileTTF(chineseFont, 36.0f, &config,
+                                 io.Fonts->GetGlyphRangesChineseFull());
+  } else {
+    io.Fonts->AddFontDefault();
+  }
 
-    // Chinese glyph ranges do not include the warning sign used by the
-    // experimental-feature notice. Merge that single glyph from Windows'
-    // symbol font so the original label is rendered instead of as '?'.
-    auto const symbolFont = "C:\\Windows\\Fonts\\seguisym.ttf";
-    if (std::filesystem::exists(symbolFont)) {
-        static constexpr ImWchar warningGlyphRange[]{0x26A0, 0x26A0, 0};
-        ImFontConfig symbolConfig{};
-        symbolConfig.MergeMode = true;
-        symbolConfig.PixelSnapH = true;
-        symbolConfig.OversampleH = 2;
-        symbolConfig.OversampleV = 2;
-        io.Fonts->AddFontFromFileTTF(symbolFont, 36.0f, &symbolConfig, warningGlyphRange);
-    }
+  // Chinese glyph ranges do not include the warning sign used by the
+  // experimental-feature notice. Merge that single glyph from Windows'
+  // symbol font so the original label is rendered instead of as '?'.
+  auto const symbolFont = "C:\\Windows\\Fonts\\seguisym.ttf";
+  if (std::filesystem::exists(symbolFont)) {
+    static constexpr ImWchar warningGlyphRange[]{0x26A0, 0x26A0, 0};
+    ImFontConfig symbolConfig{};
+    symbolConfig.MergeMode = true;
+    symbolConfig.PixelSnapH = true;
+    symbolConfig.OversampleH = 2;
+    symbolConfig.OversampleV = 2;
+    io.Fonts->AddFontFromFileTTF(symbolFont, 36.0f, &symbolConfig,
+                                 warningGlyphRange);
+  }
 }
 
 LRESULT forwardToGame(HWND window, UINT message, WPARAM wParam, LPARAM lParam) {
-    if ((message == WM_KEYDOWN || message == WM_SYSKEYDOWN) && wParam < gGameKeysDown.size()) {
-        gGameKeysDown[static_cast<std::size_t>(wParam)] = true;
-    } else if ((message == WM_KEYUP || message == WM_SYSKEYUP) && wParam < gGameKeysDown.size()) {
-        gGameKeysDown[static_cast<std::size_t>(wParam)] = false;
-    }
-    switch (message) {
-    case WM_LBUTTONDOWN: gGameMouseButtonsDown[0] = true; break;
-    case WM_LBUTTONUP: gGameMouseButtonsDown[0] = false; break;
-    case WM_RBUTTONDOWN: gGameMouseButtonsDown[1] = true; break;
-    case WM_RBUTTONUP: gGameMouseButtonsDown[1] = false; break;
-    case WM_MBUTTONDOWN: gGameMouseButtonsDown[2] = true; break;
-    case WM_MBUTTONUP: gGameMouseButtonsDown[2] = false; break;
-    case WM_XBUTTONDOWN: gGameMouseButtonsDown[GET_XBUTTON_WPARAM(wParam) == XBUTTON1 ? 3 : 4] = true; break;
-    case WM_XBUTTONUP: gGameMouseButtonsDown[GET_XBUTTON_WPARAM(wParam) == XBUTTON1 ? 3 : 4] = false; break;
-    default: break;
-    }
-    return gOriginalWndProc ? CallWindowProcW(gOriginalWndProc, window, message, wParam, lParam)
-                            : DefWindowProcW(window, message, wParam, lParam);
+  if ((message == WM_KEYDOWN || message == WM_SYSKEYDOWN) &&
+      wParam < gGameKeysDown.size()) {
+    gGameKeysDown[static_cast<std::size_t>(wParam)] = true;
+  } else if ((message == WM_KEYUP || message == WM_SYSKEYUP) &&
+             wParam < gGameKeysDown.size()) {
+    gGameKeysDown[static_cast<std::size_t>(wParam)] = false;
+  }
+  switch (message) {
+  case WM_LBUTTONDOWN:
+    gGameMouseButtonsDown[0] = true;
+    break;
+  case WM_LBUTTONUP:
+    gGameMouseButtonsDown[0] = false;
+    break;
+  case WM_RBUTTONDOWN:
+    gGameMouseButtonsDown[1] = true;
+    break;
+  case WM_RBUTTONUP:
+    gGameMouseButtonsDown[1] = false;
+    break;
+  case WM_MBUTTONDOWN:
+    gGameMouseButtonsDown[2] = true;
+    break;
+  case WM_MBUTTONUP:
+    gGameMouseButtonsDown[2] = false;
+    break;
+  case WM_XBUTTONDOWN:
+    gGameMouseButtonsDown[GET_XBUTTON_WPARAM(wParam) == XBUTTON1 ? 3 : 4] =
+        true;
+    break;
+  case WM_XBUTTONUP:
+    gGameMouseButtonsDown[GET_XBUTTON_WPARAM(wParam) == XBUTTON1 ? 3 : 4] =
+        false;
+    break;
+  default:
+    break;
+  }
+  return gOriginalWndProc ? CallWindowProcW(gOriginalWndProc, window, message,
+                                            wParam, lParam)
+                          : DefWindowProcW(window, message, wParam, lParam);
 }
 
 void releaseGameInput(HWND window) {
-    // Minecraft has already seen these down events. Send matching releases
-    // before the menu starts swallowing input, otherwise movement/use remains
-    // latched after the physical key is released while ImGui is open.
-    input::MenuInputHandoffScope inputHandoff;
-    for (std::size_t key = 0; key < gGameKeysDown.size(); ++key) {
-        if (!gGameKeysDown[key]) continue;
-        auto const virtualKey = static_cast<UINT>(key);
-        auto scanCode = MapVirtualKeyW(virtualKey, MAPVK_VK_TO_VSC);
-        auto const extended = virtualKey == VK_LEFT || virtualKey == VK_UP
-            || virtualKey == VK_RIGHT || virtualKey == VK_DOWN
-            || virtualKey == VK_PRIOR || virtualKey == VK_NEXT
-            || virtualKey == VK_END || virtualKey == VK_HOME
-            || virtualKey == VK_INSERT || virtualKey == VK_DELETE
-            || virtualKey == VK_DIVIDE || virtualKey == VK_NUMLOCK;
-        LPARAM keyUp = 1 | (static_cast<LPARAM>(scanCode) << 16) | (1LL << 30) | (1LL << 31);
-        if (extended) keyUp |= 1LL << 24;
-        auto const systemKey = virtualKey == VK_MENU || virtualKey == VK_LMENU || virtualKey == VK_RMENU;
-        forwardToGame(window, systemKey ? WM_SYSKEYUP : WM_KEYUP, virtualKey, keyUp);
-    }
+  // Minecraft has already seen these down events. Send matching releases
+  // before the menu starts swallowing input, otherwise movement/use remains
+  // latched after the physical key is released while ImGui is open.
+  input::MenuInputHandoffScope inputHandoff;
+  for (std::size_t key = 0; key < gGameKeysDown.size(); ++key) {
+    if (!gGameKeysDown[key])
+      continue;
+    auto const virtualKey = static_cast<UINT>(key);
+    auto scanCode = MapVirtualKeyW(virtualKey, MAPVK_VK_TO_VSC);
+    auto const extended = virtualKey == VK_LEFT || virtualKey == VK_UP ||
+                          virtualKey == VK_RIGHT || virtualKey == VK_DOWN ||
+                          virtualKey == VK_PRIOR || virtualKey == VK_NEXT ||
+                          virtualKey == VK_END || virtualKey == VK_HOME ||
+                          virtualKey == VK_INSERT || virtualKey == VK_DELETE ||
+                          virtualKey == VK_DIVIDE || virtualKey == VK_NUMLOCK;
+    LPARAM keyUp =
+        1 | (static_cast<LPARAM>(scanCode) << 16) | (1LL << 30) | (1LL << 31);
+    if (extended)
+      keyUp |= 1LL << 24;
+    auto const systemKey = virtualKey == VK_MENU || virtualKey == VK_LMENU ||
+                           virtualKey == VK_RMENU;
+    forwardToGame(window, systemKey ? WM_SYSKEYUP : WM_KEYUP, virtualKey,
+                  keyUp);
+  }
 
-    POINT cursor{};
-    GetCursorPos(&cursor);
-    ScreenToClient(window, &cursor);
-    auto const mousePosition = MAKELPARAM(cursor.x, cursor.y);
-    constexpr std::array<UINT, 5> upMessages{
-        WM_LBUTTONUP, WM_RBUTTONUP, WM_MBUTTONUP, WM_XBUTTONUP, WM_XBUTTONUP
-    };
-    for (std::size_t button = 0; button < gGameMouseButtonsDown.size(); ++button) {
-        if (!gGameMouseButtonsDown[button]) continue;
-        WPARAM buttonParam{};
-        if (button == 3) buttonParam = MAKEWPARAM(0, XBUTTON1);
-        if (button == 4) buttonParam = MAKEWPARAM(0, XBUTTON2);
-        forwardToGame(window, upMessages[button], buttonParam, mousePosition);
-    }
-
+  POINT cursor{};
+  GetCursorPos(&cursor);
+  ScreenToClient(window, &cursor);
+  auto const mousePosition = MAKELPARAM(cursor.x, cursor.y);
+  constexpr std::array<UINT, 5> upMessages{
+      WM_LBUTTONUP, WM_RBUTTONUP, WM_MBUTTONUP, WM_XBUTTONUP, WM_XBUTTONUP};
+  for (std::size_t button = 0; button < gGameMouseButtonsDown.size();
+       ++button) {
+    if (!gGameMouseButtonsDown[button])
+      continue;
+    WPARAM buttonParam{};
+    if (button == 3)
+      buttonParam = MAKEWPARAM(0, XBUTTON1);
+    if (button == 4)
+      buttonParam = MAKEWPARAM(0, XBUTTON2);
+    forwardToGame(window, upMessages[button], buttonParam, mousePosition);
+  }
 }
 
 bool confineMouseToClientCenter(HWND window) {
-    RECT clientRect{};
-    if (!window || !GetClientRect(window, &clientRect)) return false;
-    POINT topLeft{clientRect.left, clientRect.top};
-    POINT bottomRight{clientRect.right, clientRect.bottom};
-    if (!ClientToScreen(window, &topLeft) || !ClientToScreen(window, &bottomRight)) return false;
-    RECT screenRect{topLeft.x, topLeft.y, bottomRight.x, bottomRight.y};
-    if (!ClipCursor(&screenRect)) return false;
-    return SetCursorPos(
-        (screenRect.left + screenRect.right) / 2,
-        (screenRect.top + screenRect.bottom) / 2
-    ) != FALSE;
+  RECT clientRect{};
+  if (!window || !GetClientRect(window, &clientRect))
+    return false;
+  POINT topLeft{clientRect.left, clientRect.top};
+  POINT bottomRight{clientRect.right, clientRect.bottom};
+  if (!ClientToScreen(window, &topLeft) ||
+      !ClientToScreen(window, &bottomRight))
+    return false;
+  RECT screenRect{topLeft.x, topLeft.y, bottomRight.x, bottomRight.y};
+  if (!ClipCursor(&screenRect))
+    return false;
+  return SetCursorPos((screenRect.left + screenRect.right) / 2,
+                      (screenRect.top + screenRect.bottom) / 2) != FALSE;
 }
 
 void prepareMouseHandoff(HWND window) {
-    if (!window) return;
+  if (!window)
+    return;
 
-    // ImGui keeps button/position state independently from Win32. Clear it
-    // before Minecraft resumes relative mouse input so the closing click can
-    // never survive into the first gameplay frame.
-    if (gImGuiInitialized && ImGui::GetCurrentContext()) {
-        auto& io = ImGui::GetIO();
-        for (bool& down : io.MouseDown) down = false;
-        io.MouseWheel = 0.0f;
-        io.MouseWheelH = 0.0f;
-        io.MousePos = ImVec2(-FLT_MAX, -FLT_MAX);
-    }
-    gGameMouseButtonsDown.fill(false);
+  // ImGui keeps button/position state independently from Win32. Clear it
+  // before Minecraft resumes relative mouse input so the closing click can
+  // never survive into the first gameplay frame.
+  if (gImGuiInitialized && ImGui::GetCurrentContext()) {
+    auto &io = ImGui::GetIO();
+    for (bool &down : io.MouseDown)
+      down = false;
+    io.MouseWheel = 0.0f;
+    io.MouseWheelH = 0.0f;
+    io.MousePos = ImVec2(-FLT_MAX, -FLT_MAX);
+  }
+  gGameMouseButtonsDown.fill(false);
 
-    // A full-screen menu can leave the absolute OS cursor anywhere. Bedrock
-    // converts that absolute position back to relative-look input when it
-    // captures the mouse again; centering first prevents a one-frame camera
-    // jump proportional to the distance from the menu button to the center.
-    if (confineMouseToClientCenter(window)) {
-        gMouseHandoffActive.store(true, std::memory_order_release);
-    }
+  // A full-screen menu can leave the absolute OS cursor anywhere. Bedrock
+  // converts that absolute position back to relative-look input when it
+  // captures the mouse again; centering first prevents a one-frame camera
+  // jump proportional to the distance from the menu button to the center.
+  if (confineMouseToClientCenter(window)) {
+    gMouseHandoffActive.store(true, std::memory_order_release);
+  }
 }
 
 void maintainMouseHandoff(HWND window) {
-    if (!gMouseHandoffActive.load(std::memory_order_acquire) || !window) return;
-    if (!structure::isInputTransitionBlocked()) {
-        // Keep the client-area clip installed after the transition. Minecraft
-        // replaces it itself when opening one of its own UI screens, while
-        // releasing it here left the cursor free to reach the title-bar close
-        // button before gameplay input had recaptured it.
-        gMouseHandoffActive.store(false, std::memory_order_release);
-        return;
-    }
-    confineMouseToClientCenter(window);
+  if (!gMouseHandoffActive.load(std::memory_order_acquire) || !window)
+    return;
+  if (!structure::isInputTransitionBlocked()) {
+    // Keep the client-area clip installed after the transition. Minecraft
+    // replaces it itself when opening one of its own UI screens, while
+    // releasing it here left the cursor free to reach the title-bar close
+    // button before gameplay input had recaptured it.
+    gMouseHandoffActive.store(false, std::memory_order_release);
+    return;
+  }
+  confineMouseToClientCenter(window);
 }
 
 bool isMenuInputMessage(UINT message) {
-    switch (message) {
-    case WM_INPUT:
-    case WM_INPUT_DEVICE_CHANGE:
-    case WM_MOUSEMOVE:
-    case WM_LBUTTONDOWN:
-    case WM_LBUTTONUP:
-    case WM_RBUTTONDOWN:
-    case WM_RBUTTONUP:
-    case WM_MBUTTONDOWN:
-    case WM_MBUTTONUP:
-    case WM_XBUTTONDOWN:
-    case WM_XBUTTONUP:
-    case WM_MOUSEWHEEL:
-    case WM_MOUSEHWHEEL:
-    case WM_KEYDOWN:
-    case WM_KEYUP:
-    case WM_SYSKEYDOWN:
-    case WM_SYSKEYUP:
-    case WM_CHAR:
-        return true;
-    default:
-        return false;
-    }
+  switch (message) {
+  case WM_INPUT:
+  case WM_INPUT_DEVICE_CHANGE:
+  case WM_MOUSEMOVE:
+  case WM_LBUTTONDOWN:
+  case WM_LBUTTONUP:
+  case WM_RBUTTONDOWN:
+  case WM_RBUTTONUP:
+  case WM_MBUTTONDOWN:
+  case WM_MBUTTONUP:
+  case WM_XBUTTONDOWN:
+  case WM_XBUTTONUP:
+  case WM_MOUSEWHEEL:
+  case WM_MOUSEHWHEEL:
+  case WM_KEYDOWN:
+  case WM_KEYUP:
+  case WM_SYSKEYDOWN:
+  case WM_SYSKEYUP:
+  case WM_CHAR:
+    return true;
+  default:
+    return false;
+  }
 }
 
 bool isFullscreenKeyMessage(UINT message, WPARAM wParam) {
-    return wParam == VK_F11
-        && (message == WM_KEYDOWN || message == WM_KEYUP
-            || message == WM_SYSKEYDOWN || message == WM_SYSKEYUP);
+  return wParam == VK_F11 &&
+         (message == WM_KEYDOWN || message == WM_KEYUP ||
+          message == WM_SYSKEYDOWN || message == WM_SYSKEYUP);
 }
 
-LRESULT consumeMenuInputMessage(HWND window, UINT message, WPARAM wParam, LPARAM lParam) {
-    if (message == WM_INPUT) {
-        // Foreground RIM_INPUT must reach DefWindowProc for User32 cleanup,
-        // but must not be forwarded to Minecraft's original WndProc.
-        return DefWindowProcW(window, message, wParam, lParam);
+LRESULT consumeMenuInputMessage(HWND window, UINT message, WPARAM wParam,
+                                LPARAM lParam) {
+  if (message == WM_INPUT) {
+    // Foreground RIM_INPUT must reach DefWindowProc for User32 cleanup,
+    // but must not be forwarded to Minecraft's original WndProc.
+    return DefWindowProcW(window, message, wParam, lParam);
+  }
+  return 1;
+}
+
+LRESULT CALLBACK windowProc(HWND window, UINT message, WPARAM wParam,
+                            LPARAM lParam) {
+  if (message == kMsgRestoreNativeCursor) {
+    ::SetCursor(::LoadCursorW(nullptr, IDC_ARROW));
+    return 0;
+  }
+  if (message == WM_KILLFOCUS ||
+      (message == WM_ACTIVATEAPP && wParam == FALSE)) {
+    structure::resetHotkeyState();
+    gMouseHandoffActive.store(false, std::memory_order_release);
+    ClipCursor(nullptr);
+  }
+  if (!gShuttingDown.load(std::memory_order_acquire) && message == WM_KEYDOWN &&
+      wParam == VK_F11 && (lParam & (1LL << 30)) == 0) {
+    // Fullscreen transition may replace or resize the swap-chain buffers.
+    // Tear down the whole D3D11On12 side before Minecraft handles F11; a
+    // ResizeBuffers hook alone is too late for renderer paths that start
+    // their transition directly from the window message.
+    {
+      std::lock_guard lock(gResourceMutex);
+      releaseGraphicsBackend();
+      gGraphicsResumeAt.store(GetTickCount64() +
+                                  kFullscreenGraphicsResumeDelayMs,
+                              std::memory_order_release);
     }
+    logger().info("ImGui graphics backend suspended for fullscreen transition");
+  }
+  auto const guiWasVisible = structure::isGuiVisible();
+  if (!gShuttingDown.load(std::memory_order_acquire) && gImGuiInitialized &&
+      (message == WM_KEYDOWN || message == WM_SYSKEYDOWN) &&
+      structure::handleGuiHotkeyKeyDown(static_cast<unsigned int>(wParam))) {
+    if (!guiWasVisible && structure::isGuiVisible())
+      releaseGameInput(window);
+    if (guiWasVisible && !structure::isGuiVisible())
+      confineMouseToClientCenter(window);
     return 1;
-}
-
-LRESULT CALLBACK windowProc(HWND window, UINT message, WPARAM wParam, LPARAM lParam) {
-    if (message == kMsgRestoreNativeCursor) {
-        ::SetCursor(::LoadCursorW(nullptr, IDC_ARROW));
-        return 0;
+  }
+  if (!gShuttingDown.load(std::memory_order_acquire) && gImGuiInitialized &&
+      (message == WM_KEYUP || message == WM_SYSKEYUP) &&
+      structure::handleGuiHotkeyKeyUp(static_cast<unsigned int>(wParam))) {
+    return 1;
+  }
+  if (!gShuttingDown.load(std::memory_order_acquire) && gImGuiInitialized &&
+      (message == WM_MOUSEWHEEL || message == WM_MOUSEHWHEEL) &&
+      structure::handleMouseWheelDelta(
+          static_cast<int>(GET_WHEEL_DELTA_WPARAM(wParam)))) {
+    return 1;
+  }
+  if ((message == WM_KEYUP || message == WM_SYSKEYUP) && wParam == VK_ESCAPE &&
+      gConsumeEscapeRelease.exchange(false, std::memory_order_acq_rel)) {
+    return 1;
+  }
+  // Mouse middle/side buttons can be bound as hotkeys too. They arrive as their
+  // own window messages, so translate them to virtual-key codes and route them
+  // through the same capture/trigger path as the keyboard.
+  if (!gShuttingDown.load(std::memory_order_acquire) && gImGuiInitialized) {
+    unsigned int mouseKey = 0;
+    switch (message) {
+    case WM_MBUTTONDOWN:
+    case WM_MBUTTONUP:
+      mouseKey = VK_MBUTTON;
+      break;
+    case WM_XBUTTONDOWN:
+    case WM_XBUTTONUP:
+      mouseKey =
+          GET_XBUTTON_WPARAM(wParam) == XBUTTON1 ? VK_XBUTTON1 : VK_XBUTTON2;
+      break;
+    default:
+      break;
     }
-    if (message == WM_KILLFOCUS || (message == WM_ACTIVATEAPP && wParam == FALSE)) {
-        structure::resetHotkeyState();
-        gMouseHandoffActive.store(false, std::memory_order_release);
-        ClipCursor(nullptr);
-    }
-    if (!gShuttingDown.load(std::memory_order_acquire)
-        && message == WM_KEYDOWN && wParam == VK_F11
-        && (lParam & (1LL << 30)) == 0) {
-        // Fullscreen transition may replace or resize the swap-chain buffers.
-        // Tear down the whole D3D11On12 side before Minecraft handles F11; a
-        // ResizeBuffers hook alone is too late for renderer paths that start
-        // their transition directly from the window message.
-        {
-            std::lock_guard lock(gResourceMutex);
-            releaseGraphicsBackend();
-            gGraphicsResumeAt.store(
-                GetTickCount64() + kFullscreenGraphicsResumeDelayMs,
-                std::memory_order_release
-            );
-        }
-        logger().info("ImGui graphics backend suspended for fullscreen transition");
-    }
-    auto const guiWasVisible = structure::isGuiVisible();
-    if (!gShuttingDown.load(std::memory_order_acquire) && gImGuiInitialized
-        && (message == WM_KEYDOWN || message == WM_SYSKEYDOWN)
-        && structure::handleGuiHotkeyKeyDown(static_cast<unsigned int>(wParam))) {
-        if (!guiWasVisible && structure::isGuiVisible()) releaseGameInput(window);
-        if (guiWasVisible && !structure::isGuiVisible()) confineMouseToClientCenter(window);
-        return 1;
-    }
-    if (!gShuttingDown.load(std::memory_order_acquire) && gImGuiInitialized
-        && (message == WM_KEYUP || message == WM_SYSKEYUP)
-        && structure::handleGuiHotkeyKeyUp(static_cast<unsigned int>(wParam))) {
-        return 1;
-    }
-    if ((message == WM_KEYUP || message == WM_SYSKEYUP) && wParam == VK_ESCAPE
-        && gConsumeEscapeRelease.exchange(false, std::memory_order_acq_rel)) {
-        return 1;
-    }
-    // Mouse middle/side buttons can be bound as hotkeys too. They arrive as their
-    // own window messages, so translate them to virtual-key codes and route them
-    // through the same capture/trigger path as the keyboard.
-    if (!gShuttingDown.load(std::memory_order_acquire) && gImGuiInitialized) {
-        unsigned int mouseKey = 0;
-        switch (message) {
-        case WM_MBUTTONDOWN:
-        case WM_MBUTTONUP:
-            mouseKey = VK_MBUTTON;
-            break;
-        case WM_XBUTTONDOWN:
-        case WM_XBUTTONUP:
-            mouseKey = GET_XBUTTON_WPARAM(wParam) == XBUTTON1 ? VK_XBUTTON1 : VK_XBUTTON2;
-            break;
-        default:
-            break;
-        }
-        if (mouseKey != 0) {
-            if (message == WM_MBUTTONDOWN || message == WM_XBUTTONDOWN) {
-                if (structure::handleGuiHotkeyKeyDown(mouseKey)) {
-                    if (!guiWasVisible && structure::isGuiVisible()) releaseGameInput(window);
-                    if (guiWasVisible && !structure::isGuiVisible()) confineMouseToClientCenter(window);
-                    return 1;
-                }
-            } else if (structure::handleGuiHotkeyKeyUp(mouseKey)) {
-                return 1;
-            }
-        }
-    }
-    if (!gShuttingDown.load(std::memory_order_acquire) && gImGuiInitialized && structure::isGuiVisible()) {
-        gMouseHandoffActive.store(false, std::memory_order_release);
-        ClipCursor(nullptr);
-        ImGui_ImplWin32_WndProcHandler(window, message, wParam, lParam);
-        if (isFullscreenKeyMessage(message, wParam)) {
-            return gOriginalWndProc
-                ? CallWindowProcW(gOriginalWndProc, window, message, wParam, lParam)
-                : DefWindowProcW(window, message, wParam, lParam);
-        }
-        if (message == WM_KEYDOWN && wParam == VK_ESCAPE) {
-            gConsumeEscapeRelease.store(true, std::memory_order_release);
-            structure::requestOpenGui();
+    if (mouseKey != 0) {
+      if (message == WM_MBUTTONDOWN || message == WM_XBUTTONDOWN) {
+        if (structure::handleGuiHotkeyKeyDown(mouseKey)) {
+          if (!guiWasVisible && structure::isGuiVisible())
+            releaseGameInput(window);
+          if (guiWasVisible && !structure::isGuiVisible())
             confineMouseToClientCenter(window);
-            return 1;
+          return 1;
         }
-        if (isMenuInputMessage(message)) {
-            return consumeMenuInputMessage(window, message, wParam, lParam);
-        }
+      } else if (structure::handleGuiHotkeyKeyUp(mouseKey)) {
+        return 1;
+      }
     }
-    if (structure::isMenuInputCaptured()
-        && isMenuInputMessage(message)
-        && !isFullscreenKeyMessage(message, wParam)) {
-        return consumeMenuInputMessage(window, message, wParam, lParam);
+  }
+  if (!gShuttingDown.load(std::memory_order_acquire) && gImGuiInitialized &&
+      structure::isGuiVisible()) {
+    gMouseHandoffActive.store(false, std::memory_order_release);
+    ClipCursor(nullptr);
+    ImGui_ImplWin32_WndProcHandler(window, message, wParam, lParam);
+    if (isFullscreenKeyMessage(message, wParam)) {
+      return gOriginalWndProc ? CallWindowProcW(gOriginalWndProc, window,
+                                                message, wParam, lParam)
+                              : DefWindowProcW(window, message, wParam, lParam);
     }
-    return forwardToGame(window, message, wParam, lParam);
+    if (message == WM_KEYDOWN && wParam == VK_ESCAPE) {
+      gConsumeEscapeRelease.store(true, std::memory_order_release);
+      structure::requestOpenGui();
+      confineMouseToClientCenter(window);
+      return 1;
+    }
+    if (isMenuInputMessage(message)) {
+      return consumeMenuInputMessage(window, message, wParam, lParam);
+    }
+  }
+  if (structure::isMenuInputCaptured() && isMenuInputMessage(message) &&
+      !isFullscreenKeyMessage(message, wParam)) {
+    return consumeMenuInputMessage(window, message, wParam, lParam);
+  }
+  return forwardToGame(window, message, wParam, lParam);
 }
 
-void executeCommandListsHook(ID3D12CommandQueue* queue, UINT count, ID3D12CommandList* const* lists) {
-    if (!gGameQueue && queue->GetDesc().Type == D3D12_COMMAND_LIST_TYPE_DIRECT) {
-        std::lock_guard lock(gResourceMutex);
-        if (!gGameQueue) {
-            gGameQueue = queue;
-            gGameQueue->AddRef();
-        }
-    }
-    gOriginalExecuteCommandLists(queue, count, lists);
-}
-
-bool initializeImGui(IDXGISwapChain* swapChain) {
-    if (gImGuiInitialized && gGraphicsInitialized) return true;
-    if (GetTickCount64() < gGraphicsResumeAt.load(std::memory_order_acquire)) return false;
-
-    // Every failed attempt starts the next Present from a known empty graphics
-    // state. This also cleans partial COM objects left by a failed API call.
-    releaseGraphicsBackend();
-    if (SUCCEEDED(swapChain->GetDevice(__uuidof(ID3D11Device), reinterpret_cast<void**>(&gDevice)))) {
-        gDevice->GetImmediateContext(&gDeviceContext);
-    } else {
-        if (!gGameQueue) return false;
-        ID3D12Device* device12{};
-        if (FAILED(swapChain->GetDevice(__uuidof(ID3D12Device), reinterpret_cast<void**>(&device12)))) return false;
-        auto const result = D3D11On12CreateDevice(
-            device12,
-            D3D11_CREATE_DEVICE_BGRA_SUPPORT,
-            nullptr,
-            0,
-            reinterpret_cast<IUnknown**>(&gGameQueue),
-            1,
-            0,
-            &gDevice,
-            &gDeviceContext,
-            nullptr
-        );
-        device12->Release();
-        if (FAILED(result) || !gDevice) {
-            releaseGraphicsBackend();
-            return false;
-        }
-        if (FAILED(gDevice->QueryInterface(__uuidof(ID3D11On12Device), reinterpret_cast<void**>(&gDevice11On12)))) {
-            releaseGraphicsBackend();
-            return false;
-        }
-    }
-
-    DXGI_SWAP_CHAIN_DESC description{};
-    if (FAILED(swapChain->GetDesc(&description))) {
-        releaseGraphicsBackend();
-        return false;
-    }
-    auto const window = description.OutputWindow ? description.OutputWindow : findProcessWindow();
-    if (!window || (gWindow && window != gWindow)) {
-        releaseGraphicsBackend();
-        return false;
-    }
-
-    if (!gImGuiInitialized) {
-        IMGUI_CHECKVERSION();
-        ImGui::CreateContext();
-        ImGui::StyleColorsDark();
-        loadFonts();
-        if (!ImGui_ImplWin32_Init(window)) {
-            ui::resetFluentTheme();
-            ImGui::DestroyContext();
-            releaseGraphicsBackend();
-            return false;
-        }
-        gWindow = window;
-        gOriginalWndProc = reinterpret_cast<WNDPROC>(
-            SetWindowLongPtrW(gWindow, GWLP_WNDPROC, reinterpret_cast<LONG_PTR>(windowProc))
-        );
-        gImGuiInitialized = true;
-        logger().info("Injected Dear ImGui overlay initialized");
-    }
-    if (!ImGui_ImplDX11_Init(gDevice, gDeviceContext)) {
-        releaseGraphicsBackend();
-        return false;
-    }
-    gGraphicsInitialized = true;
-    gActiveSwapChain = swapChain;
-    logger().info("ImGui graphics backend initialized");
-    return true;
-}
-
-void render(IDXGISwapChain* swapChain) {
-    if (gShuttingDown.load(std::memory_order_acquire)) return;
-    if (gRendering.exchange(true, std::memory_order_acq_rel)) return;
-    struct Reset { ~Reset() { gRendering.store(false, std::memory_order_release); } } reset;
+void executeCommandListsHook(ID3D12CommandQueue *queue, UINT count,
+                             ID3D12CommandList *const *lists) {
+  if (!gGameQueue && queue->GetDesc().Type == D3D12_COMMAND_LIST_TYPE_DIRECT) {
     std::lock_guard lock(gResourceMutex);
-    if (!canUseSwapChainLocked(swapChain)) return;
-
-    // Initialize the backend and install the WndProc on the first usable
-    // Present even while the menu is hidden. This matches ChiyanMap's proven
-    // lifecycle: input must be ready before a hotkey can make the UI visible.
-    // D3D12 startup may not have exposed its command queue yet, so a failed
-    // attempt is intentionally retried on the next Present.
-    if (!initializeImGui(swapChain)) return;
-    structure::processPendingActions();
-    auto const showGui = structure::isGuiVisible();
-    auto const showHud = !showGui && structure::hasHudInfo();
-    if (gGuiVisibleLastFrame != showGui) {
-        if (!showGui) {
-            prepareMouseHandoff(gWindow);
-            PostMessageW(gWindow, kMsgRestoreNativeCursor, 0, 0);
-        }
+    if (!gGameQueue) {
+      gGameQueue = queue;
+      gGameQueue->AddRef();
     }
-    gGuiVisibleLastFrame = showGui;
-    if (!showGui) maintainMouseHandoff(gWindow);
-    ImGui::GetIO().MouseDrawCursor = showGui;
-    auto const showHint = structure::actionHintActive();
-    if (!showGui && !showHud && !showHint) return;
+  }
+  gOriginalExecuteCommandLists(queue, count, lists);
+}
 
-    if (showGui) ClipCursor(nullptr);
+bool initializeImGui(IDXGISwapChain *swapChain) {
+  if (gImGuiInitialized && gGraphicsInitialized)
+    return true;
+  if (GetTickCount64() < gGraphicsResumeAt.load(std::memory_order_acquire))
+    return false;
 
-    auto draw = [](ID3D11RenderTargetView* target) {
-        gDeviceContext->OMSetRenderTargets(1, &target, nullptr);
-        ImGui_ImplDX11_NewFrame();
-        ImGui_ImplWin32_NewFrame();
-        ImGui::NewFrame();
-        if (structure::isGuiVisible()) {
-            structure::renderGui();
-            // The close button changes visibility during this render call,
-            // after the frame-level transition check above.
-            if (!structure::isGuiVisible()) {
-                prepareMouseHandoff(gWindow);
-                PostMessageW(gWindow, kMsgRestoreNativeCursor, 0, 0);
-                gGuiVisibleLastFrame = false;
-            }
-        } else {
-            structure::renderHud();
-            structure::renderMaterialHud();
-        }
-        structure::renderActionHint();
-        ImGui::Render();
-        ImGui_ImplDX11_RenderDrawData(ImGui::GetDrawData());
-        ID3D11RenderTargetView* empty{};
-        gDeviceContext->OMSetRenderTargets(1, &empty, nullptr);
-    };
+  // Every failed attempt starts the next Present from a known empty graphics
+  // state. This also cleans partial COM objects left by a failed API call.
+  releaseGraphicsBackend();
+  if (SUCCEEDED(swapChain->GetDevice(__uuidof(ID3D11Device),
+                                     reinterpret_cast<void **>(&gDevice)))) {
+    gDevice->GetImmediateContext(&gDeviceContext);
+  } else {
+    if (!gGameQueue)
+      return false;
+    ID3D12Device *device12{};
+    if (FAILED(swapChain->GetDevice(__uuidof(ID3D12Device),
+                                    reinterpret_cast<void **>(&device12))))
+      return false;
+    auto const result = D3D11On12CreateDevice(
+        device12, D3D11_CREATE_DEVICE_BGRA_SUPPORT, nullptr, 0,
+        reinterpret_cast<IUnknown **>(&gGameQueue), 1, 0, &gDevice,
+        &gDeviceContext, nullptr);
+    device12->Release();
+    if (FAILED(result) || !gDevice) {
+      releaseGraphicsBackend();
+      return false;
+    }
+    if (FAILED(gDevice->QueryInterface(
+            __uuidof(ID3D11On12Device),
+            reinterpret_cast<void **>(&gDevice11On12)))) {
+      releaseGraphicsBackend();
+      return false;
+    }
+  }
 
-    if (gDevice11On12) {
-        UINT index{};
-        IDXGISwapChain3* swapChain3{};
-        if (SUCCEEDED(swapChain->QueryInterface(
-                __uuidof(IDXGISwapChain3),
-                reinterpret_cast<void**>(&swapChain3)
-            ))) {
-            index = swapChain3->GetCurrentBackBufferIndex();
-            swapChain3->Release();
-        }
+  DXGI_SWAP_CHAIN_DESC description{};
+  if (FAILED(swapChain->GetDesc(&description))) {
+    releaseGraphicsBackend();
+    return false;
+  }
+  auto const window =
+      description.OutputWindow ? description.OutputWindow : findProcessWindow();
+  if (!window || (gWindow && window != gWindow)) {
+    releaseGraphicsBackend();
+    return false;
+  }
 
-        ID3D12Resource* backBuffer{};
-        auto const getBufferResult = swapChain->GetBuffer(
-                index,
-                __uuidof(ID3D12Resource),
-                reinterpret_cast<void**>(&backBuffer)
-            );
-        if (FAILED(getBufferResult)) {
-            logGraphicsFailure(swapChain, "GetBuffer(D3D12)", getBufferResult);
-            return;
-        }
-        ID3D11Resource* wrappedBuffer{};
-        D3D11_RESOURCE_FLAGS resourceFlags{D3D11_BIND_RENDER_TARGET};
-        auto const wrappedResult = gDevice11On12->CreateWrappedResource(
-            backBuffer,
-            &resourceFlags,
-            D3D12_RESOURCE_STATE_PRESENT,
-            D3D12_RESOURCE_STATE_PRESENT,
-            __uuidof(ID3D11Resource),
-            reinterpret_cast<void**>(&wrappedBuffer)
-        );
-        backBuffer->Release();
-        if (FAILED(wrappedResult) || !wrappedBuffer) {
-            logGraphicsFailure(swapChain, "CreateWrappedResource", wrappedResult);
-            return;
-        }
+  if (!gImGuiInitialized) {
+    IMGUI_CHECKVERSION();
+    ImGui::CreateContext();
+    ImGui::StyleColorsDark();
+    loadFonts();
+    if (!ImGui_ImplWin32_Init(window)) {
+      ui::resetFluentTheme();
+      ImGui::DestroyContext();
+      releaseGraphicsBackend();
+      return false;
+    }
+    gWindow = window;
+    gOriginalWndProc = reinterpret_cast<WNDPROC>(SetWindowLongPtrW(
+        gWindow, GWLP_WNDPROC, reinterpret_cast<LONG_PTR>(windowProc)));
+    gImGuiInitialized = true;
+    logger().info("Injected Dear ImGui overlay initialized");
+  }
+  if (!ImGui_ImplDX11_Init(gDevice, gDeviceContext)) {
+    releaseGraphicsBackend();
+    return false;
+  }
+  gGraphicsInitialized = true;
+  gActiveSwapChain = swapChain;
+  logger().info("ImGui graphics backend initialized");
+  return true;
+}
 
-        ID3D11RenderTargetView* target{};
-        auto const targetResult = gDevice->CreateRenderTargetView(wrappedBuffer, nullptr, &target);
-        if (SUCCEEDED(targetResult) && target) {
-            gDevice11On12->AcquireWrappedResources(&wrappedBuffer, 1);
-            draw(target);
-            gDevice11On12->ReleaseWrappedResources(&wrappedBuffer, 1);
-            gDeviceContext->Flush();
-        } else {
-            logGraphicsFailure(swapChain, "CreateRenderTargetView(D3D11On12)", targetResult);
-        }
-        if (target) target->Release();
-        wrappedBuffer->Release();
+void render(IDXGISwapChain *swapChain) {
+  if (gShuttingDown.load(std::memory_order_acquire))
+    return;
+  if (gRendering.exchange(true, std::memory_order_acq_rel))
+    return;
+  struct Reset {
+    ~Reset() { gRendering.store(false, std::memory_order_release); }
+  } reset;
+  std::lock_guard lock(gResourceMutex);
+  if (!canUseSwapChainLocked(swapChain))
+    return;
+
+  // Initialize the backend and install the WndProc on the first usable
+  // Present even while the menu is hidden. This matches ChiyanMap's proven
+  // lifecycle: input must be ready before a hotkey can make the UI visible.
+  // D3D12 startup may not have exposed its command queue yet, so a failed
+  // attempt is intentionally retried on the next Present.
+  if (!initializeImGui(swapChain))
+    return;
+  structure::processPendingActions();
+  auto const showGui = structure::isGuiVisible();
+  auto const showHud = !showGui && structure::hasHudInfo();
+  if (gGuiVisibleLastFrame != showGui) {
+    if (!showGui) {
+      prepareMouseHandoff(gWindow);
+      PostMessageW(gWindow, kMsgRestoreNativeCursor, 0, 0);
+    }
+  }
+  gGuiVisibleLastFrame = showGui;
+  if (!showGui)
+    maintainMouseHandoff(gWindow);
+  ImGui::GetIO().MouseDrawCursor = showGui;
+  auto const showHint = structure::actionHintActive();
+  if (!showGui && !showHud && !showHint)
+    return;
+
+  if (showGui)
+    ClipCursor(nullptr);
+
+  auto draw = [](ID3D11RenderTargetView *target) {
+    gDeviceContext->OMSetRenderTargets(1, &target, nullptr);
+    ImGui_ImplDX11_NewFrame();
+    ImGui_ImplWin32_NewFrame();
+    ImGui::NewFrame();
+    if (structure::isGuiVisible()) {
+      structure::renderGui();
+      // The close button changes visibility during this render call,
+      // after the frame-level transition check above.
+      if (!structure::isGuiVisible()) {
+        prepareMouseHandoff(gWindow);
+        PostMessageW(gWindow, kMsgRestoreNativeCursor, 0, 0);
+        gGuiVisibleLastFrame = false;
+      }
     } else {
-        ID3D11Texture2D* backBuffer{};
-        auto const getBufferResult = swapChain->GetBuffer(
-            0,
-            __uuidof(ID3D11Texture2D),
-            reinterpret_cast<void**>(&backBuffer)
-        );
-        if (FAILED(getBufferResult)) {
-            logGraphicsFailure(swapChain, "GetBuffer(D3D11)", getBufferResult);
-            return;
-        }
-        ID3D11RenderTargetView* target{};
-        auto const result = gDevice->CreateRenderTargetView(backBuffer, nullptr, &target);
-        backBuffer->Release();
-        if (SUCCEEDED(result)) {
-            draw(target);
-            target->Release();
-        } else {
-            logGraphicsFailure(swapChain, "CreateRenderTargetView(D3D11)", result);
-        }
+      structure::renderHud();
+      structure::renderMaterialHud();
     }
-}
+    structure::renderActionHint();
+    ImGui::Render();
+    ImGui_ImplDX11_RenderDrawData(ImGui::GetDrawData());
+    ID3D11RenderTargetView *empty{};
+    gDeviceContext->OMSetRenderTargets(1, &empty, nullptr);
+  };
 
-HRESULT __stdcall presentHook(IDXGISwapChain* swapChain, UINT interval, UINT flags) {
-    render(swapChain);
-    return gOriginalPresent(swapChain, interval, flags);
-}
-
-HRESULT __stdcall present1Hook(
-    IDXGISwapChain1* swapChain,
-    UINT interval,
-    UINT flags,
-    DXGI_PRESENT_PARAMETERS const* parameters
-) {
-    render(swapChain);
-    return gOriginalPresent1(swapChain, interval, flags, parameters);
-}
-
-HRESULT __stdcall resizeHook(
-    IDXGISwapChain* swapChain,
-    UINT count,
-    UINT width,
-    UINT height,
-    DXGI_FORMAT format,
-    UINT flags
-) {
-    std::unique_lock lock(gResourceMutex);
-    if (gActiveSwapChain != swapChain) {
-        lock.unlock();
-        return gOriginalResizeBuffers(swapChain, count, width, height, format, flags);
+  if (gDevice11On12) {
+    UINT index{};
+    IDXGISwapChain3 *swapChain3{};
+    if (SUCCEEDED(swapChain->QueryInterface(
+            __uuidof(IDXGISwapChain3),
+            reinterpret_cast<void **>(&swapChain3)))) {
+      index = swapChain3->GetCurrentBackBufferIndex();
+      swapChain3->Release();
     }
 
-    // ResizeBuffers requires every reference to the old buffers to be gone.
-    // Although LHolo creates its wrapped back buffer and RTV per frame, the
-    // D3D11On12 context may still retain state from the last submission. Use
-    // the same full graphics-backend teardown as the proven F11 path, while
-    // preserving the ImGui context, Win32 backend and menu state.
-    prepareForSwapChainResizeLocked();
-
-    auto const result = gOriginalResizeBuffers(swapChain, count, width, height, format, flags);
-    deferGraphicsResumeAfterSwapChainResizeLocked();
-    if (FAILED(result)) {
-        logGraphicsFailure(swapChain, "ResizeBuffers", result);
+    ID3D12Resource *backBuffer{};
+    auto const getBufferResult =
+        swapChain->GetBuffer(index, __uuidof(ID3D12Resource),
+                             reinterpret_cast<void **>(&backBuffer));
+    if (FAILED(getBufferResult)) {
+      logGraphicsFailure(swapChain, "GetBuffer(D3D12)", getBufferResult);
+      return;
     }
-    return result;
+    ID3D11Resource *wrappedBuffer{};
+    D3D11_RESOURCE_FLAGS resourceFlags{D3D11_BIND_RENDER_TARGET};
+    auto const wrappedResult = gDevice11On12->CreateWrappedResource(
+        backBuffer, &resourceFlags, D3D12_RESOURCE_STATE_PRESENT,
+        D3D12_RESOURCE_STATE_PRESENT, __uuidof(ID3D11Resource),
+        reinterpret_cast<void **>(&wrappedBuffer));
+    backBuffer->Release();
+    if (FAILED(wrappedResult) || !wrappedBuffer) {
+      logGraphicsFailure(swapChain, "CreateWrappedResource", wrappedResult);
+      return;
+    }
+
+    ID3D11RenderTargetView *target{};
+    auto const targetResult =
+        gDevice->CreateRenderTargetView(wrappedBuffer, nullptr, &target);
+    if (SUCCEEDED(targetResult) && target) {
+      gDevice11On12->AcquireWrappedResources(&wrappedBuffer, 1);
+      draw(target);
+      gDevice11On12->ReleaseWrappedResources(&wrappedBuffer, 1);
+      gDeviceContext->Flush();
+    } else {
+      logGraphicsFailure(swapChain, "CreateRenderTargetView(D3D11On12)",
+                         targetResult);
+    }
+    if (target)
+      target->Release();
+    wrappedBuffer->Release();
+  } else {
+    ID3D11Texture2D *backBuffer{};
+    auto const getBufferResult = swapChain->GetBuffer(
+        0, __uuidof(ID3D11Texture2D), reinterpret_cast<void **>(&backBuffer));
+    if (FAILED(getBufferResult)) {
+      logGraphicsFailure(swapChain, "GetBuffer(D3D11)", getBufferResult);
+      return;
+    }
+    ID3D11RenderTargetView *target{};
+    auto const result =
+        gDevice->CreateRenderTargetView(backBuffer, nullptr, &target);
+    backBuffer->Release();
+    if (SUCCEEDED(result)) {
+      draw(target);
+      target->Release();
+    } else {
+      logGraphicsFailure(swapChain, "CreateRenderTargetView(D3D11)", result);
+    }
+  }
 }
 
-HRESULT __stdcall resize1Hook(
-    IDXGISwapChain3* swapChain,
-    UINT count,
-    UINT width,
-    UINT height,
-    DXGI_FORMAT format,
-    UINT flags,
-    UINT const* creationNodeMask,
-    IUnknown* const* presentQueue
-) {
-    std::unique_lock lock(gResourceMutex);
-    if (gActiveSwapChain != static_cast<IDXGISwapChain*>(swapChain)) {
-        lock.unlock();
-        return gOriginalResizeBuffers1(
-            swapChain,
-            count,
-            width,
-            height,
-            format,
-            flags,
-            creationNodeMask,
-            presentQueue
-        );
-    }
-    prepareForSwapChainResizeLocked();
-    auto const result = gOriginalResizeBuffers1(
-        swapChain,
-        count,
-        width,
-        height,
-        format,
-        flags,
-        creationNodeMask,
-        presentQueue
-    );
-    deferGraphicsResumeAfterSwapChainResizeLocked();
-    if (FAILED(result)) {
-        logGraphicsFailure(swapChain, "ResizeBuffers1", result);
-    }
-    return result;
+HRESULT __stdcall presentHook(IDXGISwapChain *swapChain, UINT interval,
+                              UINT flags) {
+  render(swapChain);
+  return gOriginalPresent(swapChain, interval, flags);
 }
 
-bool installHook(void* target, void* detour, void** original) {
-    return target && MH_CreateHook(target, detour, original) == MH_OK && MH_EnableHook(target) == MH_OK;
+HRESULT __stdcall present1Hook(IDXGISwapChain1 *swapChain, UINT interval,
+                               UINT flags,
+                               DXGI_PRESENT_PARAMETERS const *parameters) {
+  render(swapChain);
+  return gOriginalPresent1(swapChain, interval, flags, parameters);
 }
 
-void removeHook(void*& target) {
-    if (!target) return;
-    MH_DisableHook(target);
-    MH_RemoveHook(target);
-    target = nullptr;
+HRESULT __stdcall resizeHook(IDXGISwapChain *swapChain, UINT count, UINT width,
+                             UINT height, DXGI_FORMAT format, UINT flags) {
+  std::unique_lock lock(gResourceMutex);
+  if (gActiveSwapChain != swapChain) {
+    lock.unlock();
+    return gOriginalResizeBuffers(swapChain, count, width, height, format,
+                                  flags);
+  }
+
+  // ResizeBuffers requires every reference to the old buffers to be gone.
+  // Although LHolo creates its wrapped back buffer and RTV per frame, the
+  // D3D11On12 context may still retain state from the last submission. Use
+  // the same full graphics-backend teardown as the proven F11 path, while
+  // preserving the ImGui context, Win32 backend and menu state.
+  prepareForSwapChainResizeLocked();
+
+  auto const result =
+      gOriginalResizeBuffers(swapChain, count, width, height, format, flags);
+  deferGraphicsResumeAfterSwapChainResizeLocked();
+  if (FAILED(result)) {
+    logGraphicsFailure(swapChain, "ResizeBuffers", result);
+  }
+  return result;
+}
+
+HRESULT __stdcall resize1Hook(IDXGISwapChain3 *swapChain, UINT count,
+                              UINT width, UINT height, DXGI_FORMAT format,
+                              UINT flags, UINT const *creationNodeMask,
+                              IUnknown *const *presentQueue) {
+  std::unique_lock lock(gResourceMutex);
+  if (gActiveSwapChain != static_cast<IDXGISwapChain *>(swapChain)) {
+    lock.unlock();
+    return gOriginalResizeBuffers1(swapChain, count, width, height, format,
+                                   flags, creationNodeMask, presentQueue);
+  }
+  prepareForSwapChainResizeLocked();
+  auto const result =
+      gOriginalResizeBuffers1(swapChain, count, width, height, format, flags,
+                              creationNodeMask, presentQueue);
+  deferGraphicsResumeAfterSwapChainResizeLocked();
+  if (FAILED(result)) {
+    logGraphicsFailure(swapChain, "ResizeBuffers1", result);
+  }
+  return result;
+}
+
+bool installHook(void *target, void *detour, void **original) {
+  return target && MH_CreateHook(target, detour, original) == MH_OK &&
+         MH_EnableHook(target) == MH_OK;
+}
+
+void removeHook(void *&target) {
+  if (!target)
+    return;
+  MH_DisableHook(target);
+  MH_RemoveHook(target);
+  target = nullptr;
 }
 
 } // namespace
 
 bool ensureInstalled() {
-    if (gInstalled.load(std::memory_order_acquire)) return true;
-    gShuttingDown.store(false, std::memory_order_release);
-    auto window = findProcessWindow();
-    if (!window) return false;
-    auto const status = MH_Initialize();
-    if (status != MH_OK && status != MH_ERROR_ALREADY_INITIALIZED) return false;
-
-    D3D_FEATURE_LEVEL featureLevel = D3D_FEATURE_LEVEL_11_0;
-    DXGI_SWAP_CHAIN_DESC description{};
-    description.BufferCount = 1;
-    description.BufferDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
-    description.BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT;
-    description.OutputWindow = window;
-    description.SampleDesc.Count = 1;
-    description.Windowed = TRUE;
-    description.SwapEffect = DXGI_SWAP_EFFECT_DISCARD;
-    ID3D11Device* dummyDevice{};
-    ID3D11DeviceContext* dummyContext{};
-    IDXGISwapChain* dummySwapChain{};
-    if (FAILED(D3D11CreateDeviceAndSwapChain(
-            nullptr, D3D_DRIVER_TYPE_HARDWARE, nullptr, 0, &featureLevel, 1, D3D11_SDK_VERSION,
-            &description, &dummySwapChain, &dummyDevice, nullptr, &dummyContext
-        ))) return false;
-
-    auto** swapVtable = *reinterpret_cast<void***>(dummySwapChain);
-    gPresentTarget = swapVtable[kPresentVtableIndex];
-    gResizeTarget = swapVtable[kResizeBuffersVtableIndex];
-    bool ok = installHook(gPresentTarget, reinterpret_cast<void*>(presentHook), reinterpret_cast<void**>(&gOriginalPresent))
-        && installHook(gResizeTarget, reinterpret_cast<void*>(resizeHook), reinterpret_cast<void**>(&gOriginalResizeBuffers));
-    IDXGISwapChain1* swapChain1{};
-    if (SUCCEEDED(dummySwapChain->QueryInterface(__uuidof(IDXGISwapChain1), reinterpret_cast<void**>(&swapChain1)))) {
-        gPresent1Target = (*reinterpret_cast<void***>(swapChain1))[kPresent1VtableIndex];
-        ok = installHook(gPresent1Target, reinterpret_cast<void*>(present1Hook), reinterpret_cast<void**>(&gOriginalPresent1)) && ok;
-        swapChain1->Release();
-    }
-    IDXGISwapChain3* swapChain3{};
-    if (SUCCEEDED(dummySwapChain->QueryInterface(__uuidof(IDXGISwapChain3), reinterpret_cast<void**>(&swapChain3)))) {
-        gResize1Target = (*reinterpret_cast<void***>(swapChain3))[kResizeBuffers1VtableIndex];
-        ok = installHook(
-                 gResize1Target,
-                 reinterpret_cast<void*>(resize1Hook),
-                 reinterpret_cast<void**>(&gOriginalResizeBuffers1)
-             )
-          && ok;
-        swapChain3->Release();
-    } else {
-        ok = false;
-    }
-    dummySwapChain->Release();
-    dummyContext->Release();
-    dummyDevice->Release();
-
-    ID3D12Device* dummyDevice12{};
-    if (SUCCEEDED(D3D12CreateDevice(nullptr, D3D_FEATURE_LEVEL_11_0, __uuidof(ID3D12Device), reinterpret_cast<void**>(&dummyDevice12)))) {
-        D3D12_COMMAND_QUEUE_DESC queueDescription{};
-        queueDescription.Type = D3D12_COMMAND_LIST_TYPE_DIRECT;
-        ID3D12CommandQueue* dummyQueue{};
-        if (SUCCEEDED(dummyDevice12->CreateCommandQueue(&queueDescription, __uuidof(ID3D12CommandQueue), reinterpret_cast<void**>(&dummyQueue)))) {
-            gExecuteTarget = (*reinterpret_cast<void***>(dummyQueue))[kExecuteCommandListsVtableIndex];
-            ok = installHook(gExecuteTarget, reinterpret_cast<void*>(executeCommandListsHook), reinterpret_cast<void**>(&gOriginalExecuteCommandLists)) && ok;
-            dummyQueue->Release();
-        }
-        dummyDevice12->Release();
-    }
-
-
-    if (!ok) {
-        shutdown();
-        return false;
-    }
-    gInstalled.store(true, std::memory_order_release);
-    logger().info("Injected ImGui DXGI hooks installed");
+  if (gInstalled.load(std::memory_order_acquire))
     return true;
+  gShuttingDown.store(false, std::memory_order_release);
+  auto window = findProcessWindow();
+  if (!window)
+    return false;
+  auto const status = MH_Initialize();
+  if (status != MH_OK && status != MH_ERROR_ALREADY_INITIALIZED)
+    return false;
+
+  D3D_FEATURE_LEVEL featureLevel = D3D_FEATURE_LEVEL_11_0;
+  DXGI_SWAP_CHAIN_DESC description{};
+  description.BufferCount = 1;
+  description.BufferDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
+  description.BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT;
+  description.OutputWindow = window;
+  description.SampleDesc.Count = 1;
+  description.Windowed = TRUE;
+  description.SwapEffect = DXGI_SWAP_EFFECT_DISCARD;
+  ID3D11Device *dummyDevice{};
+  ID3D11DeviceContext *dummyContext{};
+  IDXGISwapChain *dummySwapChain{};
+  if (FAILED(D3D11CreateDeviceAndSwapChain(
+          nullptr, D3D_DRIVER_TYPE_HARDWARE, nullptr, 0, &featureLevel, 1,
+          D3D11_SDK_VERSION, &description, &dummySwapChain, &dummyDevice,
+          nullptr, &dummyContext)))
+    return false;
+
+  auto **swapVtable = *reinterpret_cast<void ***>(dummySwapChain);
+  gPresentTarget = swapVtable[kPresentVtableIndex];
+  gResizeTarget = swapVtable[kResizeBuffersVtableIndex];
+  bool ok = installHook(gPresentTarget, reinterpret_cast<void *>(presentHook),
+                        reinterpret_cast<void **>(&gOriginalPresent)) &&
+            installHook(gResizeTarget, reinterpret_cast<void *>(resizeHook),
+                        reinterpret_cast<void **>(&gOriginalResizeBuffers));
+  IDXGISwapChain1 *swapChain1{};
+  if (SUCCEEDED(dummySwapChain->QueryInterface(
+          __uuidof(IDXGISwapChain1), reinterpret_cast<void **>(&swapChain1)))) {
+    gPresent1Target =
+        (*reinterpret_cast<void ***>(swapChain1))[kPresent1VtableIndex];
+    ok = installHook(gPresent1Target, reinterpret_cast<void *>(present1Hook),
+                     reinterpret_cast<void **>(&gOriginalPresent1)) &&
+         ok;
+    swapChain1->Release();
+  }
+  IDXGISwapChain3 *swapChain3{};
+  if (SUCCEEDED(dummySwapChain->QueryInterface(
+          __uuidof(IDXGISwapChain3), reinterpret_cast<void **>(&swapChain3)))) {
+    gResize1Target =
+        (*reinterpret_cast<void ***>(swapChain3))[kResizeBuffers1VtableIndex];
+    ok = installHook(gResize1Target, reinterpret_cast<void *>(resize1Hook),
+                     reinterpret_cast<void **>(&gOriginalResizeBuffers1)) &&
+         ok;
+    swapChain3->Release();
+  } else {
+    ok = false;
+  }
+  dummySwapChain->Release();
+  dummyContext->Release();
+  dummyDevice->Release();
+
+  ID3D12Device *dummyDevice12{};
+  if (SUCCEEDED(D3D12CreateDevice(nullptr, D3D_FEATURE_LEVEL_11_0,
+                                  __uuidof(ID3D12Device),
+                                  reinterpret_cast<void **>(&dummyDevice12)))) {
+    D3D12_COMMAND_QUEUE_DESC queueDescription{};
+    queueDescription.Type = D3D12_COMMAND_LIST_TYPE_DIRECT;
+    ID3D12CommandQueue *dummyQueue{};
+    if (SUCCEEDED(dummyDevice12->CreateCommandQueue(
+            &queueDescription, __uuidof(ID3D12CommandQueue),
+            reinterpret_cast<void **>(&dummyQueue)))) {
+      gExecuteTarget = (*reinterpret_cast<void ***>(
+          dummyQueue))[kExecuteCommandListsVtableIndex];
+      ok =
+          installHook(
+              gExecuteTarget, reinterpret_cast<void *>(executeCommandListsHook),
+              reinterpret_cast<void **>(&gOriginalExecuteCommandLists)) &&
+          ok;
+      dummyQueue->Release();
+    }
+    dummyDevice12->Release();
+  }
+
+  if (!ok) {
+    shutdown();
+    return false;
+  }
+  gInstalled.store(true, std::memory_order_release);
+  logger().info("Injected ImGui DXGI hooks installed");
+  return true;
 }
 
 void shutdown() {
-    gShuttingDown.store(true, std::memory_order_release);
-    gMouseHandoffActive.store(false, std::memory_order_release);
-    ClipCursor(nullptr);
-    removeHook(gExecuteTarget);
-    removeHook(gResize1Target);
-    removeHook(gPresent1Target);
-    removeHook(gResizeTarget);
-    removeHook(gPresentTarget);
-    if (gOriginalWndProc && gWindow && IsWindow(gWindow)) {
-        SetWindowLongPtrW(gWindow, GWLP_WNDPROC, reinterpret_cast<LONG_PTR>(gOriginalWndProc));
-    }
-    gOriginalWndProc = nullptr;
+  gShuttingDown.store(true, std::memory_order_release);
+  gMouseHandoffActive.store(false, std::memory_order_release);
+  ClipCursor(nullptr);
+  removeHook(gExecuteTarget);
+  removeHook(gResize1Target);
+  removeHook(gPresent1Target);
+  removeHook(gResizeTarget);
+  removeHook(gPresentTarget);
+  if (gOriginalWndProc && gWindow && IsWindow(gWindow)) {
+    SetWindowLongPtrW(gWindow, GWLP_WNDPROC,
+                      reinterpret_cast<LONG_PTR>(gOriginalWndProc));
+  }
+  gOriginalWndProc = nullptr;
 
-    std::lock_guard lock(gResourceMutex);
-    releaseGraphicsBackend();
-    if (gImGuiInitialized) {
-        ImGui_ImplWin32_Shutdown();
-        ui::resetFluentTheme();
-        ImGui::DestroyContext();
-        gImGuiInitialized = false;
-    }
-    if (gGameQueue) gGameQueue->Release();
-    gGameQueue = nullptr;
-    gActiveSwapChain = nullptr;
-    gWindow = nullptr;
-    gInstalled.store(false, std::memory_order_release);
+  std::lock_guard lock(gResourceMutex);
+  releaseGraphicsBackend();
+  if (gImGuiInitialized) {
+    ImGui_ImplWin32_Shutdown();
+    ui::resetFluentTheme();
+    ImGui::DestroyContext();
+    gImGuiInitialized = false;
+  }
+  if (gGameQueue)
+    gGameQueue->Release();
+  gGameQueue = nullptr;
+  gActiveSwapChain = nullptr;
+  gWindow = nullptr;
+  gInstalled.store(false, std::memory_order_release);
 }
 
 } // namespace lholo::overlay

--- a/src/projection/runtime/ProjectionRenderFrame.cpp
+++ b/src/projection/runtime/ProjectionRenderFrame.cpp
@@ -25,8 +25,11 @@
 #include "overlay/BoundsWireframe.h"
 #include "place/PlaceHelper.h"
 #include "plugin/LHolo.h"
-#include "structure/capture/StructureCapture.h"
 #include "structure/StructureLoader.h"
+#include "structure/StructureSession.h"
+#include "structure/StructureUiState.h"
+#include "structure/capture/StructureCapture.h"
+
 
 #include <algorithm>
 #include <cmath>
@@ -52,380 +55,358 @@
 namespace lholo::projection::detail {
 namespace {
 
-auto& logger() {
-    return LHolo::getInstance().getSelf().getLogger();
-}
+auto &logger() { return LHolo::getInstance().getSelf().getLogger(); }
 
 bool enableStructureProjection(
-    ProjectionState& state,
-    BaseActorRenderContext& renderContext,
-    std::shared_ptr<structure::LoadedStructure const> loaded
-) {
-    ProjectionState next;
-    if (!prepareProjectionState(next, renderContext, std::move(loaded))) return false;
-    auto& client = renderContext.getClient();
-    auto* player = client.getLocalPlayer();
-    if (auto const anchor = ProjectionSession::getInstance().consumeAnchor()) {
-        next.anchor = BlockPos{anchor->x, anchor->y, anchor->z};
+    ProjectionState &state, BaseActorRenderContext &renderContext,
+    std::shared_ptr<structure::LoadedStructure const> loaded) {
+  ProjectionState next;
+  if (!prepareProjectionState(next, renderContext, std::move(loaded)))
+    return false;
+  auto &client = renderContext.getClient();
+  auto *player = client.getLocalPlayer();
+  if (auto const anchor = ProjectionSession::getInstance().consumeAnchor()) {
+    next.anchor = BlockPos{anchor->x, anchor->y, anchor->z};
+  } else {
+    auto const &position = player->getPosition();
+    // Player position is the feet/air cell. Default a newly loaded
+    // structure to the supporting ground cell directly below it.
+    next.anchor = BlockPos(std::floor(position.x), std::floor(position.y) - 1,
+                           std::floor(position.z));
+  }
+  state = std::move(next);
+  state.enabled = true;
+  try {
+    if (meshWorkerIsDisabledForSession()) {
+      state.asyncMeshBuildingEnabled = false;
     } else {
-        auto const& position = player->getPosition();
-        // Player position is the feet/air cell. Default a newly loaded
-        // structure to the supporting ground cell directly below it.
-        next.anchor = BlockPos(
-            std::floor(position.x),
-            std::floor(position.y) - 1,
-            std::floor(position.z)
-        );
+      state.meshWorkerGeneration = startMeshWorker();
     }
-    state = std::move(next);
-    state.enabled = true;
-    try {
-        if (meshWorkerIsDisabledForSession()) {
-            state.asyncMeshBuildingEnabled = false;
-        } else {
-            state.meshWorkerGeneration = startMeshWorker();
-        }
-    } catch (std::exception const& exception) {
-        state.asyncMeshBuildingEnabled = false;
-        disableMeshWorkerForSession();
-        logger().warn("Projection mesh worker initialization failed; using synchronous fallback: {}", exception.what());
-    } catch (...) {
-        state.asyncMeshBuildingEnabled = false;
-        disableMeshWorkerForSession();
-        logger().warn("Projection mesh worker initialization failed; using synchronous fallback");
-    }
-    attachProjectionWorldEvents(player->getLevel(), player->getDimensionBlockSource());
-    initializePublishedBuildProgress(state.structure->renderBlocks.size());
-    structure::recordProjectionAnchor(state.anchor.x, state.anchor.y, state.anchor.z);
-    logger().info(
-        "Structure projection enabled: {} renderable blocks at ({}, {}, {})",
-        state.structure->renderBlocks.size(),
-        state.anchor.x,
-        state.anchor.y,
-        state.anchor.z
-    );
-    return true;
+  } catch (std::exception const &exception) {
+    state.asyncMeshBuildingEnabled = false;
+    disableMeshWorkerForSession();
+    logger().warn("Projection mesh worker initialization failed; using "
+                  "synchronous fallback: {}",
+                  exception.what());
+  } catch (...) {
+    state.asyncMeshBuildingEnabled = false;
+    disableMeshWorkerForSession();
+    logger().warn("Projection mesh worker initialization failed; using "
+                  "synchronous fallback");
+  }
+  attachProjectionWorldEvents(player->getLevel(),
+                              player->getDimensionBlockSource());
+  initializePublishedBuildProgress(state.structure->renderBlocks.size());
+  structure::recordProjectionAnchor(state.anchor.x, state.anchor.y,
+                                    state.anchor.z);
+  logger().info(
+      "Structure projection enabled: {} renderable blocks at ({}, {}, {})",
+      state.structure->renderBlocks.size(), state.anchor.x, state.anchor.y,
+      state.anchor.z);
+  return true;
 }
 
-void suspendProjectionDimension(ProjectionState& state) {
-    auto const anchor = state.anchor;
-    place::resetDimensionSession();
-    structure::resetDimensionSession();
-    ProjectionSession::getInstance().suspendForDimension(
-        state.structureGeneration,
-        state.dimensionId,
-        ProjectionAnchor{anchor.x, anchor.y, anchor.z}
-    );
-    suspendProjectionState(state);
-    structure::showActionHint(
-        "维度发生变化，投影已暂停",
-        structure::kProjectionLifecycleHintDurationMs
-    );
+void suspendProjectionDimension(ProjectionState &state) {
+  auto const anchor = state.anchor;
+  place::resetDimensionSession();
+  structure::resetDimensionSession();
+  ProjectionSession::getInstance().suspendForDimension(
+      state.structureGeneration, state.dimensionId,
+      ProjectionAnchor{anchor.x, anchor.y, anchor.z});
+  suspendProjectionState(state);
+  structure::showActionHint("维度发生变化，投影已暂停",
+                            structure::kProjectionLifecycleHintDurationMs);
 }
 
-void renderProjection(
-    ProjectionState&          state,
-    BaseActorRenderContext&   renderContext,
-    bool                      renderAlphaLayer
-) {
-    auto& client = renderContext.getClient();
-    auto* player  = client.getLocalPlayer();
+void renderProjection(ProjectionState &state,
+                      BaseActorRenderContext &renderContext,
+                      bool renderAlphaLayer) {
+  auto &client = renderContext.getClient();
+  auto *player = client.getLocalPlayer();
 
-    auto& tessellator = renderContext.getTessellator();
-    tessellator.begin(Tessellator::DebugContextCallback{}, 128, false);
+  auto &tessellator = renderContext.getTessellator();
+  tessellator.begin(Tessellator::DebugContextCallback{}, 128, false);
 
-    if (!state.blockTessellator) {
-        tessellator.cancel();
-        return;
+  if (!state.blockTessellator) {
+    tessellator.cancel();
+    return;
+  }
+  if (!renderAlphaLayer) {
+    auto const mirrorMode = structure::getMirrorMode();
+    auto const rotationTurns = structure::getRotationQuarterTurns();
+    auto const mirror = getProjectionMirror(mirrorMode);
+    auto const rotation = getProjectionRotation(rotationTurns);
+    LegacyStructureSettings transformSettings;
+    transformSettings.setMirror(mirror);
+    transformSettings.setRotation(rotation);
+    bool const identityTransform = mirrorMode == 0 && rotationTurns == 0;
+    auto const offsetX = structure::getOffsetX();
+    auto const offsetY = structure::getOffsetY();
+    auto const offsetZ = structure::getOffsetZ();
+    auto const layerDisplayMode = structure::getLayerDisplayMode();
+    auto const layerAxis = structure::getLayerAxis();
+    auto const maxLayer = std::max(
+        0,
+        (layerAxis == 1 ? state.structure->sizeX : state.structure->sizeY) - 1);
+    auto const displayLayer =
+        std::clamp(structure::getDisplayLayer(), 0, maxLayer);
+    auto &session = ProjectionSession::getInstance();
+    auto const structureOpacity = session.opacity();
+    auto const correctionFillOpacity = session.correctionFillOpacity();
+    auto const correctionOutlineOpacity = session.correctionOutlineOpacity();
+    auto const invalidation = reconcileProjectionInvalidation(
+        state, ProjectionInvalidationSettings{
+                   .mirrorMode = mirrorMode,
+                   .rotationTurns = rotationTurns,
+                   .offsetX = offsetX,
+                   .offsetY = offsetY,
+                   .offsetZ = offsetZ,
+                   .layerDisplayMode = layerDisplayMode,
+                   .displayLayer = displayLayer,
+                   .layerAxis = layerAxis,
+                   .structureOpacity = structureOpacity,
+                   .correctionFillOpacity = correctionFillOpacity,
+                   .correctionOutlineOpacity = correctionOutlineOpacity});
+    if (invalidation.placementViewChanged()) {
+      rebuildProjectionPlacement(
+          state, player->getDimensionBlockSource(),
+          renderContext.mBlockEntityRenderDispatcher, transformSettings,
+          ProjectionPlacementSettings{.mirrorMode = mirrorMode,
+                                      .rotationTurns = rotationTurns,
+                                      .offsetX = offsetX,
+                                      .offsetY = offsetY,
+                                      .offsetZ = offsetZ,
+                                      .layerDisplayMode = layerDisplayMode,
+                                      .displayLayer = displayLayer,
+                                      .layerAxis = layerAxis,
+                                      .identityTransform = identityTransform});
     }
-    if (!renderAlphaLayer) {
-        auto const mirrorMode = structure::getMirrorMode();
-        auto const rotationTurns = structure::getRotationQuarterTurns();
-        auto const mirror = getProjectionMirror(mirrorMode);
-        auto const rotation = getProjectionRotation(rotationTurns);
-        LegacyStructureSettings transformSettings;
-        transformSettings.setMirror(mirror);
-        transformSettings.setRotation(rotation);
-        bool const identityTransform = mirrorMode == 0 && rotationTurns == 0;
-        auto const offsetX = structure::getOffsetX();
-        auto const offsetY = structure::getOffsetY();
-        auto const offsetZ = structure::getOffsetZ();
-        auto const layerDisplayMode = structure::getLayerDisplayMode();
-        auto const layerAxis = structure::getLayerAxis();
-        auto const maxLayer = std::max(
-            0,
-            (layerAxis == 1 ? state.structure->sizeX : state.structure->sizeY) - 1
-        );
-        auto const displayLayer = std::clamp(
-            structure::getDisplayLayer(), 0, maxLayer
-        );
-        auto& session = ProjectionSession::getInstance();
-        auto const structureOpacity = session.opacity();
-        auto const correctionFillOpacity = session.correctionFillOpacity();
-        auto const correctionOutlineOpacity = session.correctionOutlineOpacity();
-        auto const invalidation = reconcileProjectionInvalidation(
-            state,
-            ProjectionInvalidationSettings{
-                .mirrorMode               = mirrorMode,
-                .rotationTurns            = rotationTurns,
-                .offsetX                  = offsetX,
-                .offsetY                  = offsetY,
-                .offsetZ                  = offsetZ,
-                .layerDisplayMode         = layerDisplayMode,
-                .displayLayer             = displayLayer,
-                .layerAxis                = layerAxis,
-                .structureOpacity         = structureOpacity,
-                .correctionFillOpacity    = correctionFillOpacity,
-                .correctionOutlineOpacity = correctionOutlineOpacity
-            }
-        );
-        if (invalidation.placementViewChanged()) {
-            rebuildProjectionPlacement(
-                state,
-                player->getDimensionBlockSource(),
-                renderContext.mBlockEntityRenderDispatcher,
-                transformSettings,
-                ProjectionPlacementSettings{
-                    .mirrorMode        = mirrorMode,
-                    .rotationTurns     = rotationTurns,
-                    .offsetX           = offsetX,
-                    .offsetY           = offsetY,
-                    .offsetZ           = offsetZ,
-                    .layerDisplayMode  = layerDisplayMode,
-                    .displayLayer      = displayLayer,
-                    .layerAxis         = layerAxis,
-                    .identityTransform = identityTransform
-                }
-            );
-        }
-        ProjectionSectionBuildSettings const sectionBuildSettings{
-            .mirror                   = mirror,
-            .rotation                 = rotation,
-            .mirrorMode               = mirrorMode,
-            .rotationTurns            = rotationTurns,
-            .offsetX                  = offsetX,
-            .offsetY                  = offsetY,
-            .offsetZ                  = offsetZ,
-            .structureOpacity         = structureOpacity,
-            .correctionFillOpacity    = correctionFillOpacity,
-            .correctionOutlineOpacity = correctionOutlineOpacity,
-            .identityTransform        = identityTransform
-        };
-        processProjectionOpaqueFrame(
-            state,
-            tessellator,
-            player->getDimensionBlockSource(),
-            renderContext.getCameraPosition(),
-            transformSettings,
-            sectionBuildSettings,
-            layerDisplayMode,
-            displayLayer,
-            layerAxis
-        );
-    }
+    ProjectionSectionBuildSettings const sectionBuildSettings{
+        .mirror = mirror,
+        .rotation = rotation,
+        .mirrorMode = mirrorMode,
+        .rotationTurns = rotationTurns,
+        .offsetX = offsetX,
+        .offsetY = offsetY,
+        .offsetZ = offsetZ,
+        .structureOpacity = structureOpacity,
+        .correctionFillOpacity = correctionFillOpacity,
+        .correctionOutlineOpacity = correctionOutlineOpacity,
+        .identityTransform = identityTransform};
+    processProjectionOpaqueFrame(
+        state, tessellator, player->getDimensionBlockSource(),
+        renderContext.getCameraPosition(), transformSettings,
+        sectionBuildSettings, layerDisplayMode, displayLayer, layerAxis);
+  }
 
-    // Keep vanilla world queries at their real BlockPos, but do not upload large
-    // absolute coordinates to the GPU. Render vertices relative to the projection
-    // origin, matching the strategy used by chunk meshes.
-    BlockPos const renderOrigin{
-        state.anchor.x + structure::getOffsetX(),
-        state.anchor.y + structure::getOffsetY(),
-        state.anchor.z + structure::getOffsetZ()
+  // Keep vanilla world queries at their real BlockPos, but do not upload large
+  // absolute coordinates to the GPU. Render vertices relative to the projection
+  // origin, matching the strategy used by chunk meshes.
+  BlockPos const renderOrigin{state.anchor.x + structure::getOffsetX(),
+                              state.anchor.y + structure::getOffsetY(),
+                              state.anchor.z + structure::getOffsetZ()};
+  auto const structureOpacity = ProjectionSession::getInstance().opacity();
+  auto const &camera = renderContext.getCameraPosition();
+  if (renderAlphaLayer) {
+    // The transparent pass only submits meshes built during the preceding
+    // opaque pass. Do not leave the shared immediate tessellator active.
+    tessellator.cancel();
+  }
+
+  submitProjectedBlockActorPass(state, renderContext,
+                                player->getDimensionBlockSource(), camera,
+                                renderAlphaLayer);
+
+  auto matrix = renderContext.getWorldMatrix().push(false);
+  matrix->translate(static_cast<float>(renderOrigin.x) - camera.x,
+                    static_cast<float>(renderOrigin.y) - camera.y,
+                    static_cast<float>(renderOrigin.z) - camera.z);
+
+  auto &itemRenderer = renderContext.getItemInHandRenderer();
+  auto const &blendMaterial = itemRenderer.mMatBlendBlock.get();
+  if (!blendMaterial) {
+    tessellator.cancel();
+    return;
+  }
+
+  if (!state.terrainTextureVariant) {
+    tessellator.cancel();
+    logger().error("Projection terrain texture is not available");
+    return;
+  }
+
+  if (!state.meshPreflightDone) {
+    auto const countValid = [](auto const &meshes) {
+      return std::count_if(meshes.begin(), meshes.end(), [](auto const &mesh) {
+        return mesh && mesh->isValid();
+      });
     };
-    auto const structureOpacity = ProjectionSession::getInstance().opacity();
-    auto const& camera = renderContext.getCameraPosition();
-    if (renderAlphaLayer) {
-        // The transparent pass only submits meshes built during the preceding
-        // opaque pass. Do not leave the shared immediate tessellator active.
-        tessellator.cancel();
+    std::size_t normalMeshes{};
+    for (auto const &sectionState : state.sections) {
+      for (auto const &mesh : sectionState.meshes) {
+        if (mesh && mesh->isValid())
+          ++normalMeshes;
+      }
     }
-
-    submitProjectedBlockActorPass(
-        state,
-        renderContext,
-        player->getDimensionBlockSource(),
-        camera,
-        renderAlphaLayer
-    );
-
-    auto matrix = renderContext.getWorldMatrix().push(false);
-    matrix->translate(
-        static_cast<float>(renderOrigin.x) - camera.x,
-        static_cast<float>(renderOrigin.y) - camera.y,
-        static_cast<float>(renderOrigin.z) - camera.z
-    );
-
-    auto& itemRenderer = renderContext.getItemInHandRenderer();
-    auto const& blendMaterial = itemRenderer.mMatBlendBlock.get();
-    if (!blendMaterial) {
-        tessellator.cancel();
-        return;
+    auto const warningMeshes = countValid(state.warningFillSectionMeshes);
+    auto const outlineMeshes = countValid(state.correctionOutlineSectionMeshes);
+    auto const wrongFillMeshes = countValid(state.wrongFillSectionMeshes);
+    auto const wrongOutlineMeshes = countValid(state.wrongOutlineSectionMeshes);
+    auto const liquidMeshes = countValid(state.liquidProxySectionMeshes);
+    auto const placeholderMeshes =
+        countValid(state.blockEntityPlaceholderSectionMeshes);
+    if (normalMeshes + warningMeshes + outlineMeshes + wrongFillMeshes +
+            wrongOutlineMeshes + liquidMeshes + placeholderMeshes !=
+        0) {
+      state.meshPreflightDone = true;
     }
+  }
 
-    if (!state.terrainTextureVariant) {
-        tessellator.cancel();
-        logger().error("Projection terrain texture is not available");
-        return;
-    }
-
-    if (!state.meshPreflightDone) {
-        auto const countValid = [](auto const& meshes) {
-            return std::count_if(meshes.begin(), meshes.end(), [](auto const& mesh) {
-                return mesh && mesh->isValid();
-            });
-        };
-        std::size_t normalMeshes{};
-        for (auto const& sectionState : state.sections) {
-            for (auto const& mesh : sectionState.meshes) {
-                if (mesh && mesh->isValid()) ++normalMeshes;
-            }
-        }
-        auto const warningMeshes = countValid(state.warningFillSectionMeshes);
-        auto const outlineMeshes = countValid(state.correctionOutlineSectionMeshes);
-        auto const wrongFillMeshes = countValid(state.wrongFillSectionMeshes);
-        auto const wrongOutlineMeshes = countValid(state.wrongOutlineSectionMeshes);
-        auto const liquidMeshes = countValid(state.liquidProxySectionMeshes);
-        auto const placeholderMeshes = countValid(state.blockEntityPlaceholderSectionMeshes);
-        if (normalMeshes + warningMeshes + outlineMeshes + wrongFillMeshes
-            + wrongOutlineMeshes + liquidMeshes + placeholderMeshes != 0) {
-            state.meshPreflightDone = true;
-        }
-    }
-
-    try {
-        submitProjectionMeshPass(
-            state,
-            renderContext,
-            client,
-            renderOrigin,
-            camera,
-            structureOpacity,
-            renderAlphaLayer,
-            ProjectionSession::getInstance().structureBoundsEnabled(),
-            ProjectionSession::getInstance().correctionSeeThrough(),
-            ProjectionSession::getInstance().missingSeeThrough()
-        );
-    } catch (std::exception const& exception) {
-        logger().error("Projection immediate mesh submission failed: {}", exception.what());
-        tessellator.cancel();
-        resetProjectionState(state);
-        return;
-    } catch (...) {
-        logger().error("Projection immediate mesh submission failed with an unknown exception");
-        tessellator.cancel();
-        resetProjectionState(state);
-        return;
-    }
+  try {
+    submitProjectionMeshPass(
+        state, renderContext, client, renderOrigin, camera, structureOpacity,
+        renderAlphaLayer,
+        ProjectionSession::getInstance().structureBoundsEnabled(),
+        ProjectionSession::getInstance().correctionSeeThrough(),
+        ProjectionSession::getInstance().missingSeeThrough());
+  } catch (std::exception const &exception) {
+    logger().error("Projection immediate mesh submission failed: {}",
+                   exception.what());
+    tessellator.cancel();
+    resetProjectionState(state);
+    return;
+  } catch (...) {
+    logger().error("Projection immediate mesh submission failed with an "
+                   "unknown exception");
+    tessellator.cancel();
+    resetProjectionState(state);
+    return;
+  }
 }
 
 } // namespace
 
-bool shouldSuppressProjectionHitSelect(BlockPos const& pos) {
-    return ProjectionSession::getInstance().withLockedState(
-        [&](ProjectionState& state, overlay::BoundsWireframe&) {
-            if (state.enabled && state.structure) {
-                auto const found = state.expectedWorldBlockIndices->find(
-                    std::tuple{pos.x, pos.y, pos.z}
-                );
-                if (found != state.expectedWorldBlockIndices->end()) {
-                    auto const correctionState = state.correctionStates[found->second];
-                    if (correctionState == CorrectionState::WrongType
-                        || correctionState == CorrectionState::WrongState) {
-                        // LHolo already renders a complete red/yellow hull and
-                        // outline for this cell. Vanilla's coincident hit-select
-                        // overlay adds a second surface only while the crosshair
-                        // targets it, producing the observed flicker.
-                        return true;
-                    }
-                }
-                BlockPos const transformed{
-                    pos.x - state.anchor.x - state.cachedOffsetX,
-                    pos.y - state.anchor.y - state.cachedOffsetY,
-                    pos.z - state.anchor.z - state.cachedOffsetZ,
-                };
-                auto const local = inverseTransformStructurePosition(
-                    transformed,
-                    *state.structure,
-                    state.cachedMirror,
-                    state.cachedRotation
-                );
-                if (state.extraBlockPositions.contains(
-                        std::tuple{local.x, local.y, local.z}
-                    )) {
-                    // Extra cells use the same correction material as the
-                    // red/yellow markers, so the vanilla coincident selection
-                    // overlay must be suppressed for the same reason.
-                    return true;
-                }
+bool shouldSuppressProjectionHitSelect(BlockPos const &pos) {
+  return ProjectionSession::getInstance().withLockedState(
+      [&](ProjectionState &state, overlay::BoundsWireframe &) {
+        if (state.enabled && state.structure) {
+          auto const found = state.expectedWorldBlockIndices->find(
+              std::tuple{pos.x, pos.y, pos.z});
+          if (found != state.expectedWorldBlockIndices->end()) {
+            auto const correctionState = state.correctionStates[found->second];
+            if (correctionState == CorrectionState::WrongType ||
+                correctionState == CorrectionState::WrongState) {
+              // LHolo already renders a complete red/yellow hull and
+              // outline for this cell. Vanilla's coincident hit-select
+              // overlay adds a second surface only while the crosshair
+              // targets it, producing the observed flicker.
+              return true;
             }
-            return false;
+          }
+          BlockPos const transformed{
+              pos.x - state.anchor.x - state.cachedOffsetX,
+              pos.y - state.anchor.y - state.cachedOffsetY,
+              pos.z - state.anchor.z - state.cachedOffsetZ,
+          };
+          auto const local = inverseTransformStructurePosition(
+              transformed, *state.structure, state.cachedMirror,
+              state.cachedRotation);
+          if (state.extraBlockPositions.contains(
+                  std::tuple{local.x, local.y, local.z})) {
+            // Extra cells use the same correction material as the
+            // red/yellow markers, so the vanilla coincident selection
+            // overlay must be suppressed for the same reason.
+            return true;
+          }
         }
-    );
+        return false;
+      });
 }
 
-void renderProjectionFrame(BaseActorRenderContext& renderContext, bool renderAlphaLayer) {
-    bool clearStructure = false;
-    ProjectionSession::getInstance().withLockedState(
-        [&](ProjectionState& state, overlay::BoundsWireframe& captureBounds) {
-            if (auto const bounds = structure::capture::getBounds()) {
-                captureBounds.setBounds(
-                    BlockPos{bounds->min.x, bounds->min.y, bounds->min.z},
-                    BlockPos{bounds->max.x, bounds->max.y, bounds->max.z},
-                    0xFF0000FF
-                );
-            } else {
-                captureBounds.clear();
-            }
-            captureBounds.render(renderContext, renderAlphaLayer);
-
-            if (auto loaded = structure::getLoaded(); loaded && loaded->generation != state.structureGeneration) {
-                auto& client = renderContext.getClient();
-                auto* player = client.getLocalPlayer();
-                if (!player) return;
-                auto& session = ProjectionSession::getInstance();
-                auto const activationStatus = session.prepareDimensionActivation(
-                    loaded->generation,
-                    player->getDimensionId().value()
-                );
-                if (activationStatus == DimensionActivationStatus::Deferred) {
-                    return;
-                }
-                resetProjectionState(state);
-                if (!enableStructureProjection(state, renderContext, std::move(loaded))) {
-                    resetProjectionState(state);
-                    logger().error("Could not enable loaded structure projection");
-                } else {
-                    session.cancelDimensionSuspension();
-                    if (activationStatus == DimensionActivationStatus::Resuming) {
-                        structure::showActionHint(
-                            "已返回投影所在维度，投影已恢复",
-                            structure::kProjectionLifecycleHintDurationMs
-                        );
-                    }
-                }
-            }
-
-            if (!state.enabled) return;
-            auto& client = renderContext.getClient();
-            auto const contextStatus = classifyProjectionContext(
-                state,
-                client,
-                client.getLocalPlayer()
-            );
-            if (contextStatus == ProjectionContextStatus::Unavailable) return;
-            if (contextStatus == ProjectionContextStatus::WorldChanged) {
-                resetProjectionState(state);
-                clearStructure = true;
-                return;
-            }
-            if (contextStatus == ProjectionContextStatus::DimensionChanged) {
-                suspendProjectionDimension(state);
-                return;
-            }
-            renderProjection(state, renderContext, renderAlphaLayer);
+void renderProjectionFrame(BaseActorRenderContext &renderContext,
+                           bool renderAlphaLayer) {
+  bool clearStructure = false;
+  ProjectionSession::getInstance().withLockedState(
+      [&](ProjectionState &state, overlay::BoundsWireframe &captureBounds) {
+        if (auto const bounds = structure::capture::getBounds()) {
+          captureBounds.setBounds(
+              BlockPos{bounds->min.x, bounds->min.y, bounds->min.z},
+              BlockPos{bounds->max.x, bounds->max.y, bounds->max.z},
+              0xFF0000FF);
+        } else {
+          auto const preview =
+              lholo::structure::detail::StructureUiState::getInstance()
+                  .offsetPreview();
+          auto const previewActive =
+              preview[0] != 0 || preview[1] != 0 || preview[2] != 0;
+          if (previewActive && state.enabled && state.structure) {
+            auto const transform =
+                lholo::structure::detail::StructureSession::getInstance()
+                    .transform();
+            BlockPos const min{
+                state.anchor.x + transform.offsetX + preview[0],
+                state.anchor.y + transform.offsetY + preview[1],
+                state.anchor.z + transform.offsetZ + preview[2],
+            };
+            BlockPos const max{
+                min.x + state.structure->sizeX - 1,
+                min.y + state.structure->sizeY - 1,
+                min.z + state.structure->sizeZ - 1,
+            };
+            captureBounds.setBounds(min, max, 0xFF00FF00);
+          } else {
+            captureBounds.clear();
+          }
         }
-    );
-    if (clearStructure) structure::clear();
+        captureBounds.render(renderContext, renderAlphaLayer);
+
+        if (auto loaded = structure::getLoaded();
+            loaded && loaded->generation != state.structureGeneration) {
+          auto &client = renderContext.getClient();
+          auto *player = client.getLocalPlayer();
+          if (!player)
+            return;
+          auto &session = ProjectionSession::getInstance();
+          auto const activationStatus = session.prepareDimensionActivation(
+              loaded->generation, player->getDimensionId().value());
+          if (activationStatus == DimensionActivationStatus::Deferred) {
+            return;
+          }
+          resetProjectionState(state);
+          if (!enableStructureProjection(state, renderContext,
+                                         std::move(loaded))) {
+            resetProjectionState(state);
+            logger().error("Could not enable loaded structure projection");
+          } else {
+            session.cancelDimensionSuspension();
+            if (activationStatus == DimensionActivationStatus::Resuming) {
+              structure::showActionHint(
+                  "已返回投影所在维度，投影已恢复",
+                  structure::kProjectionLifecycleHintDurationMs);
+            }
+          }
+        }
+
+        if (!state.enabled)
+          return;
+        auto &client = renderContext.getClient();
+        auto const contextStatus =
+            classifyProjectionContext(state, client, client.getLocalPlayer());
+        if (contextStatus == ProjectionContextStatus::Unavailable)
+          return;
+        if (contextStatus == ProjectionContextStatus::WorldChanged) {
+          resetProjectionState(state);
+          clearStructure = true;
+          return;
+        }
+        if (contextStatus == ProjectionContextStatus::DimensionChanged) {
+          suspendProjectionDimension(state);
+          return;
+        }
+        renderProjection(state, renderContext, renderAlphaLayer);
+      });
+  if (clearStructure)
+    structure::clear();
 }
 
 } // namespace lholo::projection::detail

--- a/src/settings/SettingsStore.cpp
+++ b/src/settings/SettingsStore.cpp
@@ -10,163 +10,187 @@
 
 namespace lholo::settings {
 
-bool loadSettingsFile(std::filesystem::path const& path, Settings& out) {
-    if (!std::filesystem::exists(path)) return false;
-    std::ifstream input(path, std::ios::binary);
-    if (!input) throw std::runtime_error("无法打开配置文件");
-    auto const json = nlohmann::json::parse(input, nullptr, true, true);
+bool loadSettingsFile(std::filesystem::path const &path, Settings &out) {
+  if (!std::filesystem::exists(path))
+    return false;
+  std::ifstream input(path, std::ios::binary);
+  if (!input)
+    throw std::runtime_error("无法打开配置文件");
+  auto const json = nlohmann::json::parse(input, nullptr, true, true);
 
-    out.lastStructurePath = json.value("lastStructurePath", out.lastStructurePath);
-    out.uiScale = json.value("uiScale", out.uiScale);
-    out.opacity = json.value("opacity", out.opacity);
-    out.correctionFillOpacity = json.value("correctionFillOpacity", out.correctionFillOpacity);
-    out.correctionOutlineOpacity = json.value("correctionOutlineOpacity", out.correctionOutlineOpacity);
-    out.structureBoundsEnabled = json.value("structureBoundsEnabled", out.structureBoundsEnabled);
-    out.correctionSeeThrough = json.value("correctionSeeThrough", out.correctionSeeThrough);
-    out.missingSeeThrough = json.value("missingSeeThrough", out.missingSeeThrough);
-    out.experimentalConsent = json.value("experimentalConsent", out.experimentalConsent);
-    out.materialHudEnabled = json.value("materialHudEnabled", out.materialHudEnabled);
-    out.materialHudPosition = json.value("materialHudPosition", out.materialHudPosition);
-    out.placementRadius = json.value("placementRadius", out.placementRadius);
-    out.autoPlacementBreakCooldownSeconds = json.value(
-        "autoPlacementBreakCooldownSeconds",
-        out.autoPlacementBreakCooldownSeconds
-    );
-    out.hudEnabled = json.value("hudEnabled", out.hudEnabled);
-    out.hudShowFileName = json.value("hudShowFileName", out.hudShowFileName);
-    out.hudShowLayer = json.value("hudShowLayer", out.hudShowLayer);
-    out.hudShowOverallProgress = json.value("hudShowOverallProgress", out.hudShowOverallProgress);
-    out.hudShowProgress = json.value("hudShowProgress", out.hudShowProgress);
-    out.hudShowWrongState = json.value("hudShowWrongState", out.hudShowWrongState);
-    out.hudShowWrongType = json.value("hudShowWrongType", out.hudShowWrongType);
-    out.hudShowExtraBlocks = json.value("hudShowExtraBlocks", out.hudShowExtraBlocks);
-    out.hudShowProjectedBlockName = json.value(
-        "hudShowProjectedBlockName",
-        json.value("hudShowBlockEntity", out.hudShowProjectedBlockName)
-    );
-    out.hudPosition = json.value("hudPosition", out.hudPosition);
-    out.guiHotkey = json.value("guiHotkey", out.guiHotkey);
-    out.guiHotkeyModifiers = json.value("guiHotkeyModifiers", out.guiHotkeyModifiers);
-    out.layerIncreaseHotkey = json.value("layerIncreaseHotkey", out.layerIncreaseHotkey);
-    out.layerDecreaseHotkey = json.value("layerDecreaseHotkey", out.layerDecreaseHotkey);
-    out.layerIncreaseHotkeyModifiers
-        = json.value("layerIncreaseHotkeyModifiers", out.layerIncreaseHotkeyModifiers);
-    out.layerDecreaseHotkeyModifiers
-        = json.value("layerDecreaseHotkeyModifiers", out.layerDecreaseHotkeyModifiers);
-    out.loadProjectionHotkey = json.value("loadProjectionHotkey", out.loadProjectionHotkey);
-    out.loadProjectionHotkeyModifiers
-        = json.value("loadProjectionHotkeyModifiers", out.loadProjectionHotkeyModifiers);
-    out.closeProjectionHotkey = json.value("closeProjectionHotkey", out.closeProjectionHotkey);
-    out.closeProjectionHotkeyModifiers
-        = json.value("closeProjectionHotkeyModifiers", out.closeProjectionHotkeyModifiers);
+  out.lastStructurePath =
+      json.value("lastStructurePath", out.lastStructurePath);
+  out.uiScale = json.value("uiScale", out.uiScale);
+  out.opacity = json.value("opacity", out.opacity);
+  out.correctionFillOpacity =
+      json.value("correctionFillOpacity", out.correctionFillOpacity);
+  out.correctionOutlineOpacity =
+      json.value("correctionOutlineOpacity", out.correctionOutlineOpacity);
+  out.structureBoundsEnabled =
+      json.value("structureBoundsEnabled", out.structureBoundsEnabled);
+  out.correctionSeeThrough =
+      json.value("correctionSeeThrough", out.correctionSeeThrough);
+  out.missingSeeThrough =
+      json.value("missingSeeThrough", out.missingSeeThrough);
+  out.experimentalConsent =
+      json.value("experimentalConsent", out.experimentalConsent);
+  out.materialHudEnabled =
+      json.value("materialHudEnabled", out.materialHudEnabled);
+  out.materialHudPosition =
+      json.value("materialHudPosition", out.materialHudPosition);
+  out.placementRadius = json.value("placementRadius", out.placementRadius);
+  out.autoPlacementBreakCooldownSeconds =
+      json.value("autoPlacementBreakCooldownSeconds",
+                 out.autoPlacementBreakCooldownSeconds);
+  out.hudEnabled = json.value("hudEnabled", out.hudEnabled);
+  out.hudShowFileName = json.value("hudShowFileName", out.hudShowFileName);
+  out.hudShowLayer = json.value("hudShowLayer", out.hudShowLayer);
+  out.hudShowOverallProgress =
+      json.value("hudShowOverallProgress", out.hudShowOverallProgress);
+  out.hudShowProgress = json.value("hudShowProgress", out.hudShowProgress);
+  out.hudShowWrongState =
+      json.value("hudShowWrongState", out.hudShowWrongState);
+  out.hudShowWrongType = json.value("hudShowWrongType", out.hudShowWrongType);
+  out.hudShowExtraBlocks =
+      json.value("hudShowExtraBlocks", out.hudShowExtraBlocks);
+  out.hudShowProjectedBlockName = json.value(
+      "hudShowProjectedBlockName",
+      json.value("hudShowBlockEntity", out.hudShowProjectedBlockName));
+  out.hudPosition = json.value("hudPosition", out.hudPosition);
+  out.guiHotkey = json.value("guiHotkey", out.guiHotkey);
+  out.guiHotkeyModifiers =
+      json.value("guiHotkeyModifiers", out.guiHotkeyModifiers);
+  out.structureOffsetHotkey =
+      json.value("structureOffsetHotkey", out.structureOffsetHotkey);
+  out.structureOffsetHotkeyModifiers = json.value(
+      "structureOffsetHotkeyModifiers", out.structureOffsetHotkeyModifiers);
+  out.layerIncreaseHotkey =
+      json.value("layerIncreaseHotkey", out.layerIncreaseHotkey);
+  out.layerDecreaseHotkey =
+      json.value("layerDecreaseHotkey", out.layerDecreaseHotkey);
+  out.layerIncreaseHotkeyModifiers = json.value(
+      "layerIncreaseHotkeyModifiers", out.layerIncreaseHotkeyModifiers);
+  out.layerDecreaseHotkeyModifiers = json.value(
+      "layerDecreaseHotkeyModifiers", out.layerDecreaseHotkeyModifiers);
+  out.loadProjectionHotkey =
+      json.value("loadProjectionHotkey", out.loadProjectionHotkey);
+  out.loadProjectionHotkeyModifiers = json.value(
+      "loadProjectionHotkeyModifiers", out.loadProjectionHotkeyModifiers);
+  out.closeProjectionHotkey =
+      json.value("closeProjectionHotkey", out.closeProjectionHotkey);
+  out.closeProjectionHotkeyModifiers = json.value(
+      "closeProjectionHotkeyModifiers", out.closeProjectionHotkeyModifiers);
 
-    static char const* moveKeyNames[]{
-        "moveXMinusHotkey",
-        "moveXPlusHotkey",
-        "moveZMinusHotkey",
-        "moveZPlusHotkey",
-        "moveYPlusHotkey",
-        "moveYMinusHotkey"
-    };
-    static char const* moveModifierNames[]{
-        "moveXMinusHotkeyModifiers",
-        "moveXPlusHotkeyModifiers",
-        "moveZMinusHotkeyModifiers",
-        "moveZPlusHotkeyModifiers",
-        "moveYPlusHotkeyModifiers",
-        "moveYMinusHotkeyModifiers"
-    };
-    for (std::size_t index = 0; index < out.moveHotkeys.size(); ++index) {
-        out.moveHotkeys[index] = json.value(moveKeyNames[index], out.moveHotkeys[index]);
-        out.moveHotkeyModifiers[index]
-            = json.value(moveModifierNames[index], out.moveHotkeyModifiers[index]);
-    }
+  static char const *moveKeyNames[]{"moveXMinusHotkey", "moveXPlusHotkey",
+                                    "moveZMinusHotkey", "moveZPlusHotkey",
+                                    "moveYPlusHotkey",  "moveYMinusHotkey"};
+  static char const *moveModifierNames[]{
+      "moveXMinusHotkeyModifiers", "moveXPlusHotkeyModifiers",
+      "moveZMinusHotkeyModifiers", "moveZPlusHotkeyModifiers",
+      "moveYPlusHotkeyModifiers",  "moveYMinusHotkeyModifiers"};
+  for (std::size_t index = 0; index < out.moveHotkeys.size(); ++index) {
+    out.moveHotkeys[index] =
+        json.value(moveKeyNames[index], out.moveHotkeys[index]);
+    out.moveHotkeyModifiers[index] =
+        json.value(moveModifierNames[index], out.moveHotkeyModifiers[index]);
+  }
 
-    out.hasSavedProjection = json.value("hasSavedProjection", out.hasSavedProjection);
-    out.savedAnchorX = json.value("savedAnchorX", out.savedAnchorX);
-    out.savedAnchorY = json.value("savedAnchorY", out.savedAnchorY);
-    out.savedAnchorZ = json.value("savedAnchorZ", out.savedAnchorZ);
-    out.savedRotation = json.value("savedRotation", out.savedRotation);
-    out.savedMirror = json.value("savedMirror", out.savedMirror);
-    out.savedOffsetX = json.value("savedOffsetX", out.savedOffsetX);
-    out.savedOffsetY = json.value("savedOffsetY", out.savedOffsetY);
-    out.savedOffsetZ = json.value("savedOffsetZ", out.savedOffsetZ);
-    out.savedLayerDisplayMode = json.value("savedLayerDisplayMode", out.savedLayerDisplayMode);
-    out.savedDisplayLayer = json.value("savedDisplayLayer", out.savedDisplayLayer);
-    out.savedLayerAxis = json.value("savedLayerAxis", out.savedLayerAxis);
-    out.savedStructurePath = json.value("savedStructurePath", out.savedStructurePath);
-    return true;
+  out.hasSavedProjection =
+      json.value("hasSavedProjection", out.hasSavedProjection);
+  out.savedAnchorX = json.value("savedAnchorX", out.savedAnchorX);
+  out.savedAnchorY = json.value("savedAnchorY", out.savedAnchorY);
+  out.savedAnchorZ = json.value("savedAnchorZ", out.savedAnchorZ);
+  out.savedRotation = json.value("savedRotation", out.savedRotation);
+  out.savedMirror = json.value("savedMirror", out.savedMirror);
+  out.savedOffsetX = json.value("savedOffsetX", out.savedOffsetX);
+  out.savedOffsetY = json.value("savedOffsetY", out.savedOffsetY);
+  out.savedOffsetZ = json.value("savedOffsetZ", out.savedOffsetZ);
+  out.savedLayerDisplayMode =
+      json.value("savedLayerDisplayMode", out.savedLayerDisplayMode);
+  out.savedDisplayLayer =
+      json.value("savedDisplayLayer", out.savedDisplayLayer);
+  out.savedLayerAxis = json.value("savedLayerAxis", out.savedLayerAxis);
+  out.savedStructurePath =
+      json.value("savedStructurePath", out.savedStructurePath);
+  return true;
 }
 
-void saveSettingsFile(std::filesystem::path const& path, Settings const& settings) {
-    std::error_code error;
-    std::filesystem::create_directories(path.parent_path(), error);
-    if (error) throw std::runtime_error(error.message());
+void saveSettingsFile(std::filesystem::path const &path,
+                      Settings const &settings) {
+  std::error_code error;
+  std::filesystem::create_directories(path.parent_path(), error);
+  if (error)
+    throw std::runtime_error(error.message());
 
-    nlohmann::ordered_json const json{
-        {"version", 11},
-        {"lastStructurePath", settings.lastStructurePath},
-        {"uiScale", settings.uiScale},
-        {"opacity", settings.opacity},
-        {"correctionFillOpacity", settings.correctionFillOpacity},
-        {"correctionOutlineOpacity", settings.correctionOutlineOpacity},
-        {"structureBoundsEnabled", settings.structureBoundsEnabled},
-        {"correctionSeeThrough", settings.correctionSeeThrough},
-        {"missingSeeThrough", settings.missingSeeThrough},
-        {"experimentalConsent", settings.experimentalConsent},
-        {"materialHudEnabled", settings.materialHudEnabled},
-        {"materialHudPosition", settings.materialHudPosition},
-        {"placementRadius", settings.placementRadius},
-        {"autoPlacementBreakCooldownSeconds", settings.autoPlacementBreakCooldownSeconds},
-        {"hudEnabled", settings.hudEnabled},
-        {"hudShowFileName", settings.hudShowFileName},
-        {"hudShowLayer", settings.hudShowLayer},
-        {"hudShowOverallProgress", settings.hudShowOverallProgress},
-        {"hudShowProgress", settings.hudShowProgress},
-        {"hudShowWrongState", settings.hudShowWrongState},
-        {"hudShowWrongType", settings.hudShowWrongType},
-        {"hudShowExtraBlocks", settings.hudShowExtraBlocks},
-        {"hudShowProjectedBlockName", settings.hudShowProjectedBlockName},
-        {"hudPosition", settings.hudPosition},
-        {"guiHotkey", settings.guiHotkey},
-        {"guiHotkeyModifiers", settings.guiHotkeyModifiers},
-        {"layerIncreaseHotkey", settings.layerIncreaseHotkey},
-        {"layerDecreaseHotkey", settings.layerDecreaseHotkey},
-        {"layerIncreaseHotkeyModifiers", settings.layerIncreaseHotkeyModifiers},
-        {"layerDecreaseHotkeyModifiers", settings.layerDecreaseHotkeyModifiers},
-        {"loadProjectionHotkey", settings.loadProjectionHotkey},
-        {"loadProjectionHotkeyModifiers", settings.loadProjectionHotkeyModifiers},
-        {"closeProjectionHotkey", settings.closeProjectionHotkey},
-        {"closeProjectionHotkeyModifiers", settings.closeProjectionHotkeyModifiers},
-        {"moveXMinusHotkey", settings.moveHotkeys[0]},
-        {"moveXPlusHotkey", settings.moveHotkeys[1]},
-        {"moveZMinusHotkey", settings.moveHotkeys[2]},
-        {"moveZPlusHotkey", settings.moveHotkeys[3]},
-        {"moveYPlusHotkey", settings.moveHotkeys[4]},
-        {"moveYMinusHotkey", settings.moveHotkeys[5]},
-        {"moveXMinusHotkeyModifiers", settings.moveHotkeyModifiers[0]},
-        {"moveXPlusHotkeyModifiers", settings.moveHotkeyModifiers[1]},
-        {"moveZMinusHotkeyModifiers", settings.moveHotkeyModifiers[2]},
-        {"moveZPlusHotkeyModifiers", settings.moveHotkeyModifiers[3]},
-        {"moveYPlusHotkeyModifiers", settings.moveHotkeyModifiers[4]},
-        {"moveYMinusHotkeyModifiers", settings.moveHotkeyModifiers[5]},
-        {"hasSavedProjection", settings.hasSavedProjection},
-        {"savedAnchorX", settings.savedAnchorX},
-        {"savedAnchorY", settings.savedAnchorY},
-        {"savedAnchorZ", settings.savedAnchorZ},
-        {"savedStructurePath", settings.savedStructurePath},
-        {"savedRotation", settings.savedRotation},
-        {"savedMirror", settings.savedMirror},
-        {"savedOffsetX", settings.savedOffsetX},
-        {"savedOffsetY", settings.savedOffsetY},
-        {"savedOffsetZ", settings.savedOffsetZ},
-        {"savedLayerDisplayMode", settings.savedLayerDisplayMode},
-        {"savedDisplayLayer", settings.savedDisplayLayer},
-        {"savedLayerAxis", settings.savedLayerAxis}
-    };
-    std::ofstream output(path, std::ios::binary | std::ios::trunc);
-    if (!output) throw std::runtime_error("无法写入配置文件");
-    output << json.dump(2);
+  nlohmann::ordered_json const json{
+      {"version", 11},
+      {"lastStructurePath", settings.lastStructurePath},
+      {"uiScale", settings.uiScale},
+      {"opacity", settings.opacity},
+      {"correctionFillOpacity", settings.correctionFillOpacity},
+      {"correctionOutlineOpacity", settings.correctionOutlineOpacity},
+      {"structureBoundsEnabled", settings.structureBoundsEnabled},
+      {"correctionSeeThrough", settings.correctionSeeThrough},
+      {"missingSeeThrough", settings.missingSeeThrough},
+      {"experimentalConsent", settings.experimentalConsent},
+      {"materialHudEnabled", settings.materialHudEnabled},
+      {"materialHudPosition", settings.materialHudPosition},
+      {"placementRadius", settings.placementRadius},
+      {"autoPlacementBreakCooldownSeconds",
+       settings.autoPlacementBreakCooldownSeconds},
+      {"hudEnabled", settings.hudEnabled},
+      {"hudShowFileName", settings.hudShowFileName},
+      {"hudShowLayer", settings.hudShowLayer},
+      {"hudShowOverallProgress", settings.hudShowOverallProgress},
+      {"hudShowProgress", settings.hudShowProgress},
+      {"hudShowWrongState", settings.hudShowWrongState},
+      {"hudShowWrongType", settings.hudShowWrongType},
+      {"hudShowExtraBlocks", settings.hudShowExtraBlocks},
+      {"hudShowProjectedBlockName", settings.hudShowProjectedBlockName},
+      {"hudPosition", settings.hudPosition},
+      {"guiHotkey", settings.guiHotkey},
+      {"guiHotkeyModifiers", settings.guiHotkeyModifiers},
+      {"structureOffsetHotkey", settings.structureOffsetHotkey},
+      {"structureOffsetHotkeyModifiers",
+       settings.structureOffsetHotkeyModifiers},
+      {"layerIncreaseHotkey", settings.layerIncreaseHotkey},
+      {"layerDecreaseHotkey", settings.layerDecreaseHotkey},
+      {"layerIncreaseHotkeyModifiers", settings.layerIncreaseHotkeyModifiers},
+      {"layerDecreaseHotkeyModifiers", settings.layerDecreaseHotkeyModifiers},
+      {"loadProjectionHotkey", settings.loadProjectionHotkey},
+      {"loadProjectionHotkeyModifiers", settings.loadProjectionHotkeyModifiers},
+      {"closeProjectionHotkey", settings.closeProjectionHotkey},
+      {"closeProjectionHotkeyModifiers",
+       settings.closeProjectionHotkeyModifiers},
+      {"moveXMinusHotkey", settings.moveHotkeys[0]},
+      {"moveXPlusHotkey", settings.moveHotkeys[1]},
+      {"moveZMinusHotkey", settings.moveHotkeys[2]},
+      {"moveZPlusHotkey", settings.moveHotkeys[3]},
+      {"moveYPlusHotkey", settings.moveHotkeys[4]},
+      {"moveYMinusHotkey", settings.moveHotkeys[5]},
+      {"moveXMinusHotkeyModifiers", settings.moveHotkeyModifiers[0]},
+      {"moveXPlusHotkeyModifiers", settings.moveHotkeyModifiers[1]},
+      {"moveZMinusHotkeyModifiers", settings.moveHotkeyModifiers[2]},
+      {"moveZPlusHotkeyModifiers", settings.moveHotkeyModifiers[3]},
+      {"moveYPlusHotkeyModifiers", settings.moveHotkeyModifiers[4]},
+      {"moveYMinusHotkeyModifiers", settings.moveHotkeyModifiers[5]},
+      {"hasSavedProjection", settings.hasSavedProjection},
+      {"savedAnchorX", settings.savedAnchorX},
+      {"savedAnchorY", settings.savedAnchorY},
+      {"savedAnchorZ", settings.savedAnchorZ},
+      {"savedStructurePath", settings.savedStructurePath},
+      {"savedRotation", settings.savedRotation},
+      {"savedMirror", settings.savedMirror},
+      {"savedOffsetX", settings.savedOffsetX},
+      {"savedOffsetY", settings.savedOffsetY},
+      {"savedOffsetZ", settings.savedOffsetZ},
+      {"savedLayerDisplayMode", settings.savedLayerDisplayMode},
+      {"savedDisplayLayer", settings.savedDisplayLayer},
+      {"savedLayerAxis", settings.savedLayerAxis}};
+  std::ofstream output(path, std::ios::binary | std::ios::trunc);
+  if (!output)
+    throw std::runtime_error("无法写入配置文件");
+  output << json.dump(2);
 }
 
 } // namespace lholo::settings

--- a/src/settings/SettingsStore.h
+++ b/src/settings/SettingsStore.h
@@ -8,6 +8,8 @@
 
 #include "input/HotkeyTypes.h"
 
+#include <Windows.h>
+
 #include <array>
 #include <filesystem>
 #include <string>
@@ -15,60 +17,65 @@
 namespace lholo::settings {
 
 struct Settings {
-    std::string lastStructurePath;
-    float uiScale{2.0f};
-    float opacity{1.0f};
-    float correctionFillOpacity{0.15f};
-    float correctionOutlineOpacity{1.0f};
-    bool structureBoundsEnabled{true};
-    bool correctionSeeThrough{false};
-    bool missingSeeThrough{false};
-    bool experimentalConsent{false};
-    bool materialHudEnabled{false};
-    int materialHudPosition{3};
-    int placementRadius{4};
-    int autoPlacementBreakCooldownSeconds{10};
-    bool hudEnabled{true};
-    bool hudShowFileName{true};
-    bool hudShowLayer{true};
-    bool hudShowOverallProgress{false};
-    bool hudShowProgress{true};
-    bool hudShowWrongState{true};
-    bool hudShowWrongType{true};
-    bool hudShowExtraBlocks{true};
-    bool hudShowProjectedBlockName{true};
-    int hudPosition{1};
-    int guiHotkey{'M'};
-    int guiHotkeyModifiers{2};
-    int layerIncreaseHotkey{0x26}; // VK_UP
-    int layerDecreaseHotkey{0x28}; // VK_DOWN
-    int layerIncreaseHotkeyModifiers{2};
-    int layerDecreaseHotkeyModifiers{2};
-    int loadProjectionHotkey{0};
-    int loadProjectionHotkeyModifiers{0};
-    int closeProjectionHotkey{0};
-    int closeProjectionHotkeyModifiers{0};
-    // X-, X+, Z-, Z+, Y+, Y-
-    std::array<int, input::kMoveHotkeyCount> moveHotkeys{0x25, 0x27, 0x26, 0x28, 0x26, 0x28};
-    std::array<int, input::kMoveHotkeyCount> moveHotkeyModifiers{1, 1, 1, 1, 4, 4};
-    bool hasSavedProjection{false};
-    int savedAnchorX{};
-    int savedAnchorY{};
-    int savedAnchorZ{};
-    int savedRotation{};
-    int savedMirror{};
-    int savedOffsetX{};
-    int savedOffsetY{};
-    int savedOffsetZ{};
-    int savedLayerDisplayMode{};
-    int savedDisplayLayer{};
-    int savedLayerAxis{};
-    std::string savedStructurePath;
+  std::string lastStructurePath;
+  float uiScale{2.0f};
+  float opacity{1.0f};
+  float correctionFillOpacity{0.15f};
+  float correctionOutlineOpacity{1.0f};
+  bool structureBoundsEnabled{true};
+  bool correctionSeeThrough{false};
+  bool missingSeeThrough{false};
+  bool experimentalConsent{false};
+  bool materialHudEnabled{false};
+  int materialHudPosition{3};
+  int placementRadius{4};
+  int autoPlacementBreakCooldownSeconds{10};
+  bool hudEnabled{true};
+  bool hudShowFileName{true};
+  bool hudShowLayer{true};
+  bool hudShowOverallProgress{false};
+  bool hudShowProgress{true};
+  bool hudShowWrongState{true};
+  bool hudShowWrongType{true};
+  bool hudShowExtraBlocks{true};
+  bool hudShowProjectedBlockName{true};
+  int hudPosition{1};
+  int guiHotkey{'M'};
+  int guiHotkeyModifiers{2};
+  int structureOffsetHotkey{VK_LMENU};
+  int structureOffsetHotkeyModifiers{0};
+  int layerIncreaseHotkey{0x26}; // VK_UP
+  int layerDecreaseHotkey{0x28}; // VK_DOWN
+  int layerIncreaseHotkeyModifiers{2};
+  int layerDecreaseHotkeyModifiers{2};
+  int loadProjectionHotkey{0};
+  int loadProjectionHotkeyModifiers{0};
+  int closeProjectionHotkey{0};
+  int closeProjectionHotkeyModifiers{0};
+  // X-, X+, Z-, Z+, Y+, Y-
+  std::array<int, input::kMoveHotkeyCount> moveHotkeys{0x25, 0x27, 0x26,
+                                                       0x28, 0x26, 0x28};
+  std::array<int, input::kMoveHotkeyCount> moveHotkeyModifiers{1, 1, 1,
+                                                               1, 4, 4};
+  bool hasSavedProjection{false};
+  int savedAnchorX{};
+  int savedAnchorY{};
+  int savedAnchorZ{};
+  int savedRotation{};
+  int savedMirror{};
+  int savedOffsetX{};
+  int savedOffsetY{};
+  int savedOffsetZ{};
+  int savedLayerDisplayMode{};
+  int savedDisplayLayer{};
+  int savedLayerAxis{};
+  std::string savedStructurePath;
 };
 
 // Returns false when the file does not exist. Throws on read or parse errors.
-bool loadSettingsFile(std::filesystem::path const& path, Settings& out);
+bool loadSettingsFile(std::filesystem::path const &path, Settings &out);
 
-void saveSettingsFile(std::filesystem::path const& path, Settings const& settings);
+void saveSettingsFile(std::filesystem::path const &path,
+                      Settings const &settings);
 
 } // namespace lholo::settings

--- a/src/structure/StructureLoader.cpp
+++ b/src/structure/StructureLoader.cpp
@@ -16,23 +16,23 @@
 
 #include "structure/StructureLoader.h"
 
-#include "settings/SettingsStore.h"
-#include "structure/MaterialTracker.h"
-#include "structure/formats/StructureFormatLoaders.h"
-#include "structure/StructureSession.h"
-#include "structure/StructurePaths.h"
-#include "structure/StructureUiState.h"
-#include "ui/HotkeyFormat.h"
-#include "ui/MenuController.h"
-#include "structure/capture/StructureCapture.h"
-#include "structure/java_to_bedrock/JavaToBedrock.h"
-#include "ui/FileDialog.h"
-#include "ui/FluentTheme.h"
-#include "ui/LHoloMenu.h"
-#include "ui/MenuWidgets.h"
 #include "place/PlaceHelper.h"
 #include "plugin/LHolo.h"
 #include "projection/Projection.h"
+#include "settings/SettingsStore.h"
+#include "structure/MaterialTracker.h"
+#include "structure/StructurePaths.h"
+#include "structure/StructureSession.h"
+#include "structure/StructureUiState.h"
+#include "structure/capture/StructureCapture.h"
+#include "structure/formats/StructureFormatLoaders.h"
+#include "structure/java_to_bedrock/JavaToBedrock.h"
+#include "ui/FileDialog.h"
+#include "ui/FluentTheme.h"
+#include "ui/HotkeyFormat.h"
+#include "ui/LHoloMenu.h"
+#include "ui/MenuController.h"
+#include "ui/MenuWidgets.h"
 
 #include <algorithm>
 #include <array>
@@ -53,9 +53,9 @@
 
 #include <Windows.h>
 
+#include "imgui.h"
 #include "ll/api/mod/NativeMod.h"
 #include "ll/api/service/Bedrock.h"
-#include "imgui.h"
 #include "mc/client/game/ClientInstance.h"
 #include "mc/client/game/IClientInstance.h"
 #include "mc/client/player/LocalPlayer.h"
@@ -64,235 +64,323 @@
 namespace lholo::structure {
 namespace {
 
-constexpr std::size_t kGuiHotkeyIndex = input::hotkeyIndex(input::HotkeyId::Gui);
-constexpr std::size_t kLayerIncreaseHotkeyIndex = input::hotkeyIndex(input::HotkeyId::LayerIncrease);
-constexpr std::size_t kLayerDecreaseHotkeyIndex = input::hotkeyIndex(input::HotkeyId::LayerDecrease);
-constexpr std::size_t kLoadProjectionHotkeyIndex = input::hotkeyIndex(input::HotkeyId::LoadProjection);
-constexpr std::size_t kCloseProjectionHotkeyIndex = input::hotkeyIndex(input::HotkeyId::CloseProjection);
+constexpr std::size_t kGuiHotkeyIndex =
+    input::hotkeyIndex(input::HotkeyId::Gui);
+constexpr std::size_t kStructureOffsetHotkeyIndex =
+    input::hotkeyIndex(input::HotkeyId::StructureOffset);
+constexpr std::size_t kLayerIncreaseHotkeyIndex =
+    input::hotkeyIndex(input::HotkeyId::LayerIncrease);
+constexpr std::size_t kLayerDecreaseHotkeyIndex =
+    input::hotkeyIndex(input::HotkeyId::LayerDecrease);
+constexpr std::size_t kLoadProjectionHotkeyIndex =
+    input::hotkeyIndex(input::HotkeyId::LoadProjection);
+constexpr std::size_t kCloseProjectionHotkeyIndex =
+    input::hotkeyIndex(input::HotkeyId::CloseProjection);
 constexpr float kActionHintVerticalScreenRatio = 0.80f;
-auto& logger() {
-    return LHolo::getInstance().getSelf().getLogger();
-}
+auto &logger() { return LHolo::getInstance().getSelf().getLogger(); }
 
 bool hudContextAvailable() {
-    auto client = ll::service::getClientInstance();
-    return client && client->getLocalPlayer() && !projection::isDimensionSuspended();
+  auto client = ll::service::getClientInstance();
+  return client && client->getLocalPlayer() &&
+         !projection::isDimensionSuspended();
 }
 
-auto& uiState() {
-    return detail::StructureUiState::getInstance();
-}
+auto &uiState() { return detail::StructureUiState::getInstance(); }
 
 std::filesystem::path settingsPath() {
-    return LHolo::getInstance().getSelf().getConfigDir() / "config.json";
+  return LHolo::getInstance().getSelf().getConfigDir() / "config.json";
 }
 
 void resetWorldSession();
 
 unsigned int currentHotkeyModifiers() {
-    return uiState().currentHotkeyModifiers();
+  return uiState().currentHotkeyModifiers();
 }
 
 } // namespace
 
-void requestMaterialList() {
-    detail::requestMaterialListRefresh();
+bool handleMouseWheelDelta(int wheelDelta) {
+  if (wheelDelta == 0)
+    return false;
+  if (isGuiVisible() || isInputTransitionBlocked())
+    return false;
+
+  auto const structureOffsetHotkey =
+      uiState().inputHotkey(kStructureOffsetHotkeyIndex);
+  auto const currentModifiers = uiState().currentHotkeyModifiers();
+  bool hasStructureOffsetModifier = false;
+  switch (structureOffsetHotkey.key) {
+  case VK_MENU:
+  case VK_LMENU:
+  case VK_RMENU:
+    hasStructureOffsetModifier =
+        (currentModifiers & lholo::ui::kHotkeyModifierAlt) != 0;
+    break;
+  case VK_CONTROL:
+  case VK_LCONTROL:
+  case VK_RCONTROL:
+    hasStructureOffsetModifier =
+        (currentModifiers & lholo::ui::kHotkeyModifierControl) != 0;
+    break;
+  case VK_SHIFT:
+  case VK_LSHIFT:
+  case VK_RSHIFT:
+    hasStructureOffsetModifier =
+        (currentModifiers & lholo::ui::kHotkeyModifierShift) != 0;
+    break;
+  default:
+    hasStructureOffsetModifier =
+        (currentModifiers & structureOffsetHotkey.modifiers) ==
+        structureOffsetHotkey.modifiers;
+    break;
+  }
+  if (!hasStructureOffsetModifier)
+    return false;
+
+  auto client = ll::service::getClientInstance();
+  auto *player = client ? client->getLocalPlayer() : nullptr;
+  if (!player)
+    return false;
+
+  Vec3 const view = player->getViewVector(1.0f);
+  int offsetX{};
+  int offsetY{};
+  int offsetZ{};
+  if (!computeRelativeOffsetFromView(view.x, view.y, view.z, wheelDelta,
+                                     offsetX, offsetY, offsetZ))
+    return false;
+
+  uiState().queueOffsetDelta(offsetX, offsetY, offsetZ);
+  return true;
 }
 
+void requestMaterialList() { detail::requestMaterialListRefresh(); }
+
 void requestOpenGui() {
-    auto const opening = uiState().toggleGuiVisible();
-    if (opening) {
-        uiState().setOpeningInputBlockFrames(3);
-    } else {
-        // Consume the release half of the key/click that closed the menu.
-        // Without this, Minecraft receives an unmatched Esc or mouse-up after
-        // the ImGui window has already disappeared.
-        uiState().setBlockGameInputUntil(GetTickCount64() + 180);
-    }
+  auto const opening = uiState().toggleGuiVisible();
+  if (opening) {
+    uiState().setOpeningInputBlockFrames(3);
+  } else {
+    // Consume the release half of the key/click that closed the menu.
+    // Without this, Minecraft receives an unmatched Esc or mouse-up after
+    // the ImGui window has already disappeared.
+    uiState().setBlockGameInputUntil(GetTickCount64() + 180);
+  }
 }
 
 bool isGuiVisible() { return uiState().guiVisible(); }
 
 bool shouldShowProjectedBlockName() {
-    auto const hud = uiState().hud();
-    return hud.enabled && hud.showProjectedBlockName;
+  auto const hud = uiState().hud();
+  return hud.enabled && hud.showProjectedBlockName;
 }
 
 bool isInputTransitionBlocked() {
-    return GetTickCount64() <= uiState().blockGameInputUntil();
+  return GetTickCount64() <= uiState().blockGameInputUntil();
 }
 
 bool isMenuInputCaptured() {
-    return isGuiVisible() || isInputTransitionBlocked();
+  return isGuiVisible() || isInputTransitionBlocked();
 }
 
 bool handleGuiHotkeyKeyDown(unsigned int virtualKey) {
-    auto const modifierKey = ui::isModifierKey(virtualKey);
-    if (virtualKey == VK_CONTROL || virtualKey == VK_LCONTROL || virtualKey == VK_RCONTROL) {
-        uiState().setControlHeld(true);
-    } else if (virtualKey == VK_MENU || virtualKey == VK_LMENU || virtualKey == VK_RMENU) {
-        uiState().setAltHeld(true);
-    } else if (virtualKey == VK_SHIFT || virtualKey == VK_LSHIFT || virtualKey == VK_RSHIFT) {
-        uiState().setShiftHeld(true);
-    }
+  auto const modifierKey = ui::isModifierKey(virtualKey);
+  if (virtualKey == VK_CONTROL || virtualKey == VK_LCONTROL ||
+      virtualKey == VK_RCONTROL) {
+    uiState().setControlHeld(true);
+  } else if (virtualKey == VK_MENU || virtualKey == VK_LMENU ||
+             virtualKey == VK_RMENU) {
+    uiState().setAltHeld(true);
+  } else if (virtualKey == VK_SHIFT || virtualKey == VK_LSHIFT ||
+             virtualKey == VK_RSHIFT) {
+    uiState().setShiftHeld(true);
+  }
 
-    auto const captureIndex = uiState().capturingHotkey();
-    if (captureIndex) {
-        // F11 belongs to Minecraft's fullscreen toggle. Never capture or
-        // consume it as a mod shortcut, including while rebinding controls.
-        if (virtualKey == VK_F11) return false;
-        if (virtualKey == VK_ESCAPE) {
-            uiState().stopHotkeyCapture();
-        } else if (virtualKey == VK_DELETE || virtualKey == VK_BACK) {
-            uiState().clearHotkey(*captureIndex);
-            uiState().stopHotkeyCapture();
-            uiState().requestSettingsSave();
-        } else if (!modifierKey) {
-            auto const modifiers = currentHotkeyModifiers();
-            uiState().bindCapturedHotkey(*captureIndex, virtualKey, modifiers);
-            uiState().setIgnoreHotkeyUntil(GetTickCount64() + 250);
-            uiState().requestSettingsSave();
-        }
-        return true;
+  auto const captureIndex = uiState().capturingHotkey();
+  if (captureIndex) {
+    // F11 belongs to Minecraft's fullscreen toggle. Never capture or
+    // consume it as a mod shortcut, including while rebinding controls.
+    if (virtualKey == VK_F11)
+      return false;
+    if (virtualKey == VK_ESCAPE) {
+      uiState().stopHotkeyCapture();
+    } else if (virtualKey == VK_DELETE || virtualKey == VK_BACK) {
+      uiState().clearHotkey(*captureIndex);
+      uiState().stopHotkeyCapture();
+      uiState().requestSettingsSave();
+    } else if (!modifierKey) {
+      auto const modifiers = currentHotkeyModifiers();
+      uiState().bindCapturedHotkey(*captureIndex, virtualKey, modifiers);
+      uiState().setIgnoreHotkeyUntil(GetTickCount64() + 250);
+      uiState().requestSettingsSave();
     }
+    return true;
+  }
 
-    if (modifierKey) return false;
-
-    auto const modifiers = currentHotkeyModifiers();
-    auto const guiHotkey = uiState().inputHotkey(kGuiHotkeyIndex);
-    if (guiHotkey.key != 0 && virtualKey == guiHotkey.key
-        && modifiers == guiHotkey.modifiers) {
-        if (GetTickCount64() >= uiState().ignoreHotkeyUntil()
-            && uiState().tryPressHotkey(kGuiHotkeyIndex)) {
-            requestOpenGui();
-        }
-        return true;
-    }
-    if (isGuiVisible()) return false;
-
-    for (std::size_t index = 0; index < input::kMoveHotkeyCount; ++index) {
-        auto const hotkey = uiState().inputHotkey(index + input::kMoveHotkeyFirst);
-        if (hotkey.key == virtualKey && hotkey.modifiers == modifiers) {
-            if (GetTickCount64() >= uiState().ignoreHotkeyUntil()
-                && uiState().tryPressHotkey(index + input::kMoveHotkeyFirst)) {
-                uiState().queueMove(index);
-            }
-            return true;
-        }
-    }
-
-    auto const layerIncreaseHotkey = uiState().inputHotkey(kLayerIncreaseHotkeyIndex);
-    if (layerIncreaseHotkey.key != 0 && virtualKey == layerIncreaseHotkey.key
-        && modifiers == layerIncreaseHotkey.modifiers) {
-        if (!detail::StructureSession::getInstance().layerDisplayEnabled()) return false;
-        if (GetTickCount64() >= uiState().ignoreHotkeyUntil()
-            && uiState().tryPressHotkey(kLayerIncreaseHotkeyIndex)) {
-            uiState().queueLayerDelta(1);
-        }
-        return true;
-    }
-    auto const layerDecreaseHotkey = uiState().inputHotkey(kLayerDecreaseHotkeyIndex);
-    if (layerDecreaseHotkey.key != 0 && virtualKey == layerDecreaseHotkey.key
-        && modifiers == layerDecreaseHotkey.modifiers) {
-        if (!detail::StructureSession::getInstance().layerDisplayEnabled()) return false;
-        if (GetTickCount64() >= uiState().ignoreHotkeyUntil()
-            && uiState().tryPressHotkey(kLayerDecreaseHotkeyIndex)) {
-            uiState().queueLayerDelta(-1);
-        }
-        return true;
-    }
-    auto const loadProjectionHotkey = uiState().inputHotkey(kLoadProjectionHotkeyIndex);
-    if (loadProjectionHotkey.key != 0 && virtualKey == loadProjectionHotkey.key
-        && modifiers == loadProjectionHotkey.modifiers) {
-        if (GetTickCount64() >= uiState().ignoreHotkeyUntil()
-            && uiState().tryPressHotkey(kLoadProjectionHotkeyIndex)) {
-            uiState().queueLoadProjection();
-        }
-        return true;
-    }
-    auto const closeProjectionHotkey = uiState().inputHotkey(kCloseProjectionHotkeyIndex);
-    if (closeProjectionHotkey.key != 0 && virtualKey == closeProjectionHotkey.key
-        && modifiers == closeProjectionHotkey.modifiers) {
-        if (GetTickCount64() >= uiState().ignoreHotkeyUntil()
-            && uiState().tryPressHotkey(kCloseProjectionHotkeyIndex)) {
-            uiState().queueCloseProjection();
-        }
-        return true;
-    }
+  if (modifierKey)
     return false;
+
+  auto const modifiers = currentHotkeyModifiers();
+  auto const guiHotkey = uiState().inputHotkey(kGuiHotkeyIndex);
+  if (guiHotkey.key != 0 && virtualKey == guiHotkey.key &&
+      modifiers == guiHotkey.modifiers) {
+    if (GetTickCount64() >= uiState().ignoreHotkeyUntil() &&
+        uiState().tryPressHotkey(kGuiHotkeyIndex)) {
+      requestOpenGui();
+    }
+    return true;
+  }
+  if (isGuiVisible())
+    return false;
+
+  for (std::size_t index = 0; index < input::kMoveHotkeyCount; ++index) {
+    auto const hotkey = uiState().inputHotkey(index + input::kMoveHotkeyFirst);
+    if (hotkey.key == virtualKey && hotkey.modifiers == modifiers) {
+      if (GetTickCount64() >= uiState().ignoreHotkeyUntil() &&
+          uiState().tryPressHotkey(index + input::kMoveHotkeyFirst)) {
+        uiState().queueMove(index);
+      }
+      return true;
+    }
+  }
+
+  auto const layerIncreaseHotkey =
+      uiState().inputHotkey(kLayerIncreaseHotkeyIndex);
+  if (layerIncreaseHotkey.key != 0 && virtualKey == layerIncreaseHotkey.key &&
+      modifiers == layerIncreaseHotkey.modifiers) {
+    if (!detail::StructureSession::getInstance().layerDisplayEnabled())
+      return false;
+    if (GetTickCount64() >= uiState().ignoreHotkeyUntil() &&
+        uiState().tryPressHotkey(kLayerIncreaseHotkeyIndex)) {
+      uiState().queueLayerDelta(1);
+    }
+    return true;
+  }
+  auto const layerDecreaseHotkey =
+      uiState().inputHotkey(kLayerDecreaseHotkeyIndex);
+  if (layerDecreaseHotkey.key != 0 && virtualKey == layerDecreaseHotkey.key &&
+      modifiers == layerDecreaseHotkey.modifiers) {
+    if (!detail::StructureSession::getInstance().layerDisplayEnabled())
+      return false;
+    if (GetTickCount64() >= uiState().ignoreHotkeyUntil() &&
+        uiState().tryPressHotkey(kLayerDecreaseHotkeyIndex)) {
+      uiState().queueLayerDelta(-1);
+    }
+    return true;
+  }
+  auto const loadProjectionHotkey =
+      uiState().inputHotkey(kLoadProjectionHotkeyIndex);
+  if (loadProjectionHotkey.key != 0 && virtualKey == loadProjectionHotkey.key &&
+      modifiers == loadProjectionHotkey.modifiers) {
+    if (GetTickCount64() >= uiState().ignoreHotkeyUntil() &&
+        uiState().tryPressHotkey(kLoadProjectionHotkeyIndex)) {
+      uiState().queueLoadProjection();
+    }
+    return true;
+  }
+  auto const closeProjectionHotkey =
+      uiState().inputHotkey(kCloseProjectionHotkeyIndex);
+  if (closeProjectionHotkey.key != 0 &&
+      virtualKey == closeProjectionHotkey.key &&
+      modifiers == closeProjectionHotkey.modifiers) {
+    if (GetTickCount64() >= uiState().ignoreHotkeyUntil() &&
+        uiState().tryPressHotkey(kCloseProjectionHotkeyIndex)) {
+      uiState().queueCloseProjection();
+    }
+    return true;
+  }
+  return false;
 }
 
 bool handleGuiHotkeyKeyUp(unsigned int virtualKey) {
-    if (virtualKey == VK_CONTROL || virtualKey == VK_LCONTROL || virtualKey == VK_RCONTROL) {
-        uiState().setControlHeld(false);
-        return false;
-    }
-    if (virtualKey == VK_MENU || virtualKey == VK_LMENU || virtualKey == VK_RMENU) {
-        uiState().setAltHeld(false);
-        return false;
-    }
-    if (virtualKey == VK_SHIFT || virtualKey == VK_LSHIFT || virtualKey == VK_RSHIFT) {
-        uiState().setShiftHeld(false);
-        return false;
-    }
+  if (virtualKey == VK_CONTROL || virtualKey == VK_LCONTROL ||
+      virtualKey == VK_RCONTROL) {
+    uiState().setControlHeld(false);
+    return false;
+  }
+  if (virtualKey == VK_MENU || virtualKey == VK_LMENU ||
+      virtualKey == VK_RMENU) {
+    uiState().setAltHeld(false);
+    return false;
+  }
+  if (virtualKey == VK_SHIFT || virtualKey == VK_LSHIFT ||
+      virtualKey == VK_RSHIFT) {
+    uiState().setShiftHeld(false);
+    return false;
+  }
 
-    return uiState().releaseHotkeysForKey(virtualKey, GetTickCount64());
+  return uiState().releaseHotkeysForKey(virtualKey, GetTickCount64());
 }
 
-void resetHotkeyState() {
-    uiState().resetHotkeyState();
-}
+void resetHotkeyState() { uiState().resetHotkeyState(); }
 
 void processPendingActions() {
-    if (projection::consumeWorldExitRequest()) {
-        place::resetWorldSession();
-        capture::clear();
-        resetWorldSession();
-        showActionHint("已退出世界，投影已关闭", kProjectionLifecycleHintDurationMs);
-        return;
-    }
+  if (projection::consumeWorldExitRequest()) {
+    place::resetWorldSession();
+    capture::clear();
+    resetWorldSession();
+    showActionHint("已退出世界，投影已关闭",
+                   kProjectionLifecycleHintDurationMs);
+    return;
+  }
 
-    auto& session = detail::StructureSession::getInstance();
-    auto const pending = uiState().consumePendingHotkeyActions();
-    auto const layerActionEnabled = pending.layerDelta != 0 && session.transform().layerDisplayMode != 0;
-    bool changed = pending.offsetX != 0 || pending.offsetY != 0 || pending.offsetZ != 0 || layerActionEnabled;
-    session.adjustOffsets(pending.offsetX, pending.offsetY, pending.offsetZ);
-    if (layerActionEnabled) session.adjustDisplayLayer(pending.layerDelta);
+  auto &session = detail::StructureSession::getInstance();
+  auto const pending = uiState().consumePendingHotkeyActions();
+  auto const layerActionEnabled =
+      pending.layerDelta != 0 && session.transform().layerDisplayMode != 0;
+  bool changed = pending.offsetX != 0 || pending.offsetY != 0 ||
+                 pending.offsetZ != 0 || layerActionEnabled;
 
-    if (pending.loadProjection) {
-        restoreSavedProjection();
-        showActionHint("加载投影");
-    }
-    if (pending.closeProjection) {
-        clear();
-        saveSettings();
-        showActionHint("关闭投影");
-    }
+  if (pending.offsetX != 0 || pending.offsetY != 0 || pending.offsetZ != 0) {
+    uiState().addOffsetPreview(pending.offsetX, pending.offsetY,
+                               pending.offsetZ);
+    uiState().setOffsetPreviewDeadline(GetTickCount64() + 1000);
+  }
 
-    changed = pending.settingsSave || changed;
-    if (changed) saveSettings();
+  if (uiState().offsetPreviewActive() &&
+      GetTickCount64() >= uiState().offsetPreviewDeadline()) {
+    auto const preview = uiState().consumeOffsetPreview();
+    session.adjustOffsets(preview[0], preview[1], preview[2]);
+    changed = true;
+  }
+
+  if (layerActionEnabled)
+    session.adjustDisplayLayer(pending.layerDelta);
+
+  if (pending.loadProjection) {
+    restoreSavedProjection();
+    showActionHint("加载投影");
+  }
+  if (pending.closeProjection) {
+    clear();
+    saveSettings();
+    showActionHint("关闭投影");
+  }
+
+  changed = pending.settingsSave || changed;
+  if (changed)
+    saveSettings();
 }
 
-void resetDimensionSession() {
-    uiState().clearMaterialHud();
-}
+void resetDimensionSession() { uiState().clearMaterialHud(); }
 
 bool hasHudInfo() {
-    if (!hudContextAvailable()) return false;
-    if (!detail::StructureSession::getInstance().hasLoaded()) return false;
-    // The material HUD renders independently of the projection HUD, so the
-    // overlay must draw when it is enabled even if the projection HUD is off.
-    if (materialHudEnabled()) return true;
-    auto const hud = uiState().hud();
-    if (!hud.enabled) return false;
-    if (!hud.showFileName
-        && !hud.showLayer
-        && !hud.showOverallProgress
-        && !hud.showProgress
-        && !hud.showWrongState
-        && !hud.showWrongType
-        && !hud.showProjectedBlockName) return false;
+  if (!hudContextAvailable())
+    return false;
+  if (!detail::StructureSession::getInstance().hasLoaded())
+    return false;
+  // The material HUD renders independently of the projection HUD, so the
+  // overlay must draw when it is enabled even if the projection HUD is off.
+  if (materialHudEnabled())
     return true;
+  auto const hud = uiState().hud();
+  if (!hud.enabled)
+    return false;
+  if (!hud.showFileName && !hud.showLayer && !hud.showOverallProgress &&
+      !hud.showProgress && !hud.showWrongState && !hud.showWrongType &&
+      !hud.showProjectedBlockName)
+    return false;
+  return true;
 }
 
 namespace {
@@ -300,586 +388,567 @@ namespace {
 // renderMaterialHud (drawn right after, same frame) can stack clear of it when
 // they share a corner. `frame` guards against stale reads.
 struct ProjectionHudLayout {
-    int   frame{-1};
-    int   position{1};
-    float topY{0.0f};
-    float bottomY{0.0f};
+  int frame{-1};
+  int position{1};
+  float topY{0.0f};
+  float bottomY{0.0f};
 };
-ProjectionHudLayout  gProjectionHudLayout;
+ProjectionHudLayout gProjectionHudLayout;
 } // namespace
 
-bool experimentalConsentGiven() {
-    return uiState().experimentalConsentGiven();
-}
+bool experimentalConsentGiven() { return uiState().experimentalConsentGiven(); }
 
 void setExperimentalConsentGiven(bool given) {
-    uiState().setExperimentalConsentGiven(given);
+  uiState().setExperimentalConsentGiven(given);
 }
 
-bool materialHudEnabled() {
-    return uiState().materialHudEnabled();
-}
+bool materialHudEnabled() { return uiState().materialHudEnabled(); }
 
 void setMaterialHudEnabled(bool enabled) {
-    uiState().setMaterialHudEnabled(enabled);
+  uiState().setMaterialHudEnabled(enabled);
 }
 
-int materialHudPosition() {
-    return uiState().materialHudPosition();
-}
+int materialHudPosition() { return uiState().materialHudPosition(); }
 
 void setMaterialHudPosition(int position) {
-    uiState().setMaterialHudPosition(position);
+  uiState().setMaterialHudPosition(position);
 }
 
 void showActionHint(std::string text, std::uint64_t durationMs) {
-    uiState().setActionHint(std::move(text), GetTickCount64() + durationMs);
+  uiState().setActionHint(std::move(text), GetTickCount64() + durationMs);
 }
 
 bool actionHintActive() {
-    return GetTickCount64() < uiState().actionHintExpiry();
+  return GetTickCount64() < uiState().actionHintExpiry();
 }
 
 void renderActionHint() {
-    auto const now = GetTickCount64();
-    auto const hint = uiState().actionHint();
-    auto const expiry = hint.expiry;
-    if (now >= expiry) return;
-    if (hint.text.empty()) return;
+  auto const now = GetTickCount64();
+  auto const hint = uiState().actionHint();
+  auto const expiry = hint.expiry;
+  if (now >= expiry)
+    return;
+  if (hint.text.empty())
+    return;
 
-    auto const remaining = expiry - now;
-    float const alpha = remaining < 300 ? static_cast<float>(remaining) / 300.0f : 1.0f;
-    auto const displaySize = ImGui::GetIO().DisplaySize;
-    float const uiScale = std::clamp(
-        std::min(displaySize.x / 1920.0f, displaySize.y / 1080.0f), 1.0f, 5.0f
-    );
-    auto const metrics = lholo::ui::calculateMetrics(displaySize, uiScale);
-    lholo::ui::applyFluentTheme(metrics);
+  auto const remaining = expiry - now;
+  float const alpha =
+      remaining < 300 ? static_cast<float>(remaining) / 300.0f : 1.0f;
+  auto const displaySize = ImGui::GetIO().DisplaySize;
+  float const uiScale = std::clamp(
+      std::min(displaySize.x / 1920.0f, displaySize.y / 1080.0f), 1.0f, 5.0f);
+  auto const metrics = lholo::ui::calculateMetrics(displaySize, uiScale);
+  lholo::ui::applyFluentTheme(metrics);
 
-    // Centered horizontally, sitting just above the hotbar like JE's action bar.
-    ImGui::SetNextWindowPos(
-        ImVec2(displaySize.x * 0.5f, displaySize.y * kActionHintVerticalScreenRatio),
-        ImGuiCond_Always,
-        ImVec2(0.5f, 0.5f)
-    );
-    ImGui::PushStyleColor(ImGuiCol_WindowBg, ImVec4(0.36f, 0.20f, 0.42f, 0.86f * alpha));
-    ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(1.0f, 1.0f, 1.0f, alpha));
-    ImGui::PushStyleVar(ImGuiStyleVar_WindowRounding, metrics.rounding * 0.6f);
-    ImGui::PushStyleVar(
-        ImGuiStyleVar_WindowPadding, ImVec2(metrics.sectionPadding, metrics.gap)
-    );
-    constexpr auto flags = ImGuiWindowFlags_NoDecoration
-        | ImGuiWindowFlags_AlwaysAutoResize
-        | ImGuiWindowFlags_NoSavedSettings
-        | ImGuiWindowFlags_NoFocusOnAppearing
-        | ImGuiWindowFlags_NoBringToFrontOnFocus
-        | ImGuiWindowFlags_NoNavInputs
-        | ImGuiWindowFlags_NoNavFocus
-        | ImGuiWindowFlags_NoInputs;
-    if (ImGui::Begin("##LHoloActionHint", nullptr, flags)) {
-        ImGui::TextUnformatted(hint.text.c_str());
-    }
-    ImGui::End();
-    ImGui::PopStyleVar(2);
-    ImGui::PopStyleColor(2);
+  // Centered horizontally, sitting just above the hotbar like JE's action bar.
+  ImGui::SetNextWindowPos(
+      ImVec2(displaySize.x * 0.5f,
+             displaySize.y * kActionHintVerticalScreenRatio),
+      ImGuiCond_Always, ImVec2(0.5f, 0.5f));
+  ImGui::PushStyleColor(ImGuiCol_WindowBg,
+                        ImVec4(0.36f, 0.20f, 0.42f, 0.86f * alpha));
+  ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(1.0f, 1.0f, 1.0f, alpha));
+  ImGui::PushStyleVar(ImGuiStyleVar_WindowRounding, metrics.rounding * 0.6f);
+  ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding,
+                      ImVec2(metrics.sectionPadding, metrics.gap));
+  constexpr auto flags =
+      ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_AlwaysAutoResize |
+      ImGuiWindowFlags_NoSavedSettings | ImGuiWindowFlags_NoFocusOnAppearing |
+      ImGuiWindowFlags_NoBringToFrontOnFocus | ImGuiWindowFlags_NoNavInputs |
+      ImGuiWindowFlags_NoNavFocus | ImGuiWindowFlags_NoInputs;
+  if (ImGui::Begin("##LHoloActionHint", nullptr, flags)) {
+    ImGui::TextUnformatted(hint.text.c_str());
+  }
+  ImGui::End();
+  ImGui::PopStyleVar(2);
+  ImGui::PopStyleColor(2);
 }
 
 void renderHud() {
-    if (isGuiVisible()) return;
-    if (!hudContextAvailable()) return;
-    auto const hud = uiState().hud();
-    if (!hud.enabled) return;
-    auto const showFileName = hud.showFileName;
-    auto const showLayer = hud.showLayer;
-    auto const showOverallProgress = hud.showOverallProgress;
-    auto const showProgress = hud.showProgress;
-    auto const showWrongState = hud.showWrongState;
-    auto const showWrongType = hud.showWrongType;
-    auto const showExtraBlocks = hud.showExtraBlocks;
-    auto const showProjectedBlockName = hud.showProjectedBlockName;
-    if (!showFileName && !showLayer && !showOverallProgress && !showProgress
-        && !showWrongState && !showWrongType && !showExtraBlocks
-        && !showProjectedBlockName) return;
+  if (isGuiVisible())
+    return;
+  if (!hudContextAvailable())
+    return;
+  auto const hud = uiState().hud();
+  if (!hud.enabled)
+    return;
+  auto const showFileName = hud.showFileName;
+  auto const showLayer = hud.showLayer;
+  auto const showOverallProgress = hud.showOverallProgress;
+  auto const showProgress = hud.showProgress;
+  auto const showWrongState = hud.showWrongState;
+  auto const showWrongType = hud.showWrongType;
+  auto const showExtraBlocks = hud.showExtraBlocks;
+  auto const showProjectedBlockName = hud.showProjectedBlockName;
+  if (!showFileName && !showLayer && !showOverallProgress && !showProgress &&
+      !showWrongState && !showWrongType && !showExtraBlocks &&
+      !showProjectedBlockName)
+    return;
 
-    auto const sessionSnapshot = detail::StructureSession::getInstance().snapshot();
-    if (!sessionSnapshot.loaded) return;
-    auto const fileName = detail::pathToUtf8(sessionSnapshot.loaded->sourcePath.filename());
-    auto const layerAxis = sessionSnapshot.transform.layerAxis;
-    auto const maxLayer = layerAxis == 1 ? sessionSnapshot.maxLayerX : sessionSnapshot.maxLayerY;
+  auto const sessionSnapshot =
+      detail::StructureSession::getInstance().snapshot();
+  if (!sessionSnapshot.loaded)
+    return;
+  auto const fileName =
+      detail::pathToUtf8(sessionSnapshot.loaded->sourcePath.filename());
+  auto const layerAxis = sessionSnapshot.transform.layerAxis;
+  auto const maxLayer =
+      layerAxis == 1 ? sessionSnapshot.maxLayerX : sessionSnapshot.maxLayerY;
 
-    auto const displaySize = ImGui::GetIO().DisplaySize;
-    auto uiScale = hud.uiScale;
-    if (uiScale <= 0.0f) {
-        uiScale = std::clamp(
-            std::min(displaySize.x / 1920.0f, displaySize.y / 1080.0f),
-            1.0f,
-            5.0f
-        );
+  auto const displaySize = ImGui::GetIO().DisplaySize;
+  auto uiScale = hud.uiScale;
+  if (uiScale <= 0.0f) {
+    uiScale = std::clamp(
+        std::min(displaySize.x / 1920.0f, displaySize.y / 1080.0f), 1.0f, 5.0f);
+  }
+  auto const hudMetrics = lholo::ui::calculateMetrics(displaySize, uiScale);
+  lholo::ui::applyFluentTheme(hudMetrics);
+  auto const layerMode = sessionSnapshot.transform.layerDisplayMode;
+  auto const currentLayer =
+      std::clamp(sessionSnapshot.transform.displayLayer, 0, maxLayer);
+
+  auto const hudPosition = std::clamp(hud.position, 0, 3);
+  auto const right = hudPosition >= 2;
+  auto const bottom = (hudPosition & 1) != 0;
+  auto const margin = hudMetrics.outerPadding;
+  ImGui::SetNextWindowPos(ImVec2(right ? displaySize.x - margin : margin,
+                                 bottom ? displaySize.y - margin : margin),
+                          ImGuiCond_Always,
+                          ImVec2(right ? 1.0f : 0.0f, bottom ? 1.0f : 0.0f));
+  ImGui::SetNextWindowBgAlpha(0.68f);
+  ImGui::PushStyleVar(ImGuiStyleVar_WindowRounding, hudMetrics.rounding * 0.7f);
+  ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding,
+                      ImVec2(hudMetrics.sectionPadding, hudMetrics.gap));
+  constexpr auto flags =
+      ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_AlwaysAutoResize |
+      ImGuiWindowFlags_NoSavedSettings | ImGuiWindowFlags_NoFocusOnAppearing |
+      ImGuiWindowFlags_NoBringToFrontOnFocus | ImGuiWindowFlags_NoNavInputs |
+      ImGuiWindowFlags_NoNavFocus | ImGuiWindowFlags_NoInputs;
+  if (ImGui::Begin("##LHoloHud", nullptr, flags)) {
+    if (showFileName)
+      ImGui::Text("投影：%s", fileName.c_str());
+    if (showLayer && layerMode == 0) {
+      ImGui::TextUnformatted("显示范围：完整结构");
+    } else if (showLayer && layerMode == 1) {
+      ImGui::Text("当前层：%d / %d（%s 轴）", currentLayer, maxLayer,
+                  layerAxis == 1 ? "X" : "Y");
+    } else if (showLayer && layerMode == 2) {
+      ImGui::Text("显示范围：第 0～%d 层（%s 轴）", currentLayer,
+                  layerAxis == 1 ? "X" : "Y");
+    } else if (showLayer) {
+      ImGui::Text("显示范围：第 %d～%d 层（%s 轴）", currentLayer, maxLayer,
+                  layerAxis == 1 ? "X" : "Y");
     }
-    auto const hudMetrics = lholo::ui::calculateMetrics(displaySize, uiScale);
-    lholo::ui::applyFluentTheme(hudMetrics);
-    auto const layerMode = sessionSnapshot.transform.layerDisplayMode;
-    auto const currentLayer = std::clamp(
-        sessionSnapshot.transform.displayLayer,
-        0,
-        maxLayer
-    );
-
-    auto const hudPosition = std::clamp(hud.position, 0, 3);
-    auto const right = hudPosition >= 2;
-    auto const bottom = (hudPosition & 1) != 0;
-    auto const margin = hudMetrics.outerPadding;
-    ImGui::SetNextWindowPos(
-        ImVec2(right ? displaySize.x - margin : margin, bottom ? displaySize.y - margin : margin),
-        ImGuiCond_Always,
-        ImVec2(right ? 1.0f : 0.0f, bottom ? 1.0f : 0.0f)
-    );
-    ImGui::SetNextWindowBgAlpha(0.68f);
-    ImGui::PushStyleVar(ImGuiStyleVar_WindowRounding, hudMetrics.rounding * 0.7f);
-    ImGui::PushStyleVar(
-        ImGuiStyleVar_WindowPadding,
-        ImVec2(hudMetrics.sectionPadding, hudMetrics.gap)
-    );
-    constexpr auto flags = ImGuiWindowFlags_NoDecoration
-        | ImGuiWindowFlags_AlwaysAutoResize
-        | ImGuiWindowFlags_NoSavedSettings
-        | ImGuiWindowFlags_NoFocusOnAppearing
-        | ImGuiWindowFlags_NoBringToFrontOnFocus
-        | ImGuiWindowFlags_NoNavInputs
-        | ImGuiWindowFlags_NoNavFocus
-        | ImGuiWindowFlags_NoInputs;
-    if (ImGui::Begin("##LHoloHud", nullptr, flags)) {
-        if (showFileName) ImGui::Text("投影：%s", fileName.c_str());
-        if (showLayer && layerMode == 0) {
-            ImGui::TextUnformatted("显示范围：完整结构");
-        } else if (showLayer && layerMode == 1) {
-            ImGui::Text(
-                "当前层：%d / %d（%s 轴）",
-                currentLayer,
-                maxLayer,
-                layerAxis == 1 ? "X" : "Y"
-            );
-        } else if (showLayer && layerMode == 2) {
-            ImGui::Text(
-                "显示范围：第 0～%d 层（%s 轴）",
-                currentLayer,
-                layerAxis == 1 ? "X" : "Y"
-            );
-        } else if (showLayer) {
-            ImGui::Text(
-                "显示范围：第 %d～%d 层（%s 轴）",
-                currentLayer,
-                maxLayer,
-                layerAxis == 1 ? "X" : "Y"
-            );
-        }
-        auto const showAnyProgress = showOverallProgress || showProgress || showWrongState
-            || showWrongType || showExtraBlocks;
-        projection::BuildProgress progress{};
-        if (showAnyProgress) progress = projection::getBuildProgress();
-        if (showOverallProgress) {
-            ImGui::Text(
-                "总体进度：%llu / %llu",
-                static_cast<unsigned long long>(progress.placed),
-                static_cast<unsigned long long>(progress.total)
-            );
-        }
-        if (showProgress) {
-            ImGui::Text(
-                "建造进度：%llu / %llu",
-                static_cast<unsigned long long>(progress.visiblePlaced),
-                static_cast<unsigned long long>(progress.visibleTotal)
-            );
-        }
-        if (showWrongState && progress.wrongState != 0) {
-            ImGui::TextColored(
-                ImVec4(1.0f, 0.62f, 0.18f, 1.0f),
-                "朝向错误：%llu",
-                static_cast<unsigned long long>(progress.wrongState)
-            );
-        }
-        if (showWrongType && progress.wrongType != 0) {
-            ImGui::TextColored(
-                ImVec4(1.0f, 0.28f, 0.24f, 1.0f),
-                "放置错误：%llu",
-                static_cast<unsigned long long>(progress.wrongType)
-            );
-        }
-        if (showExtraBlocks && progress.extra != 0) {
-            ImGui::TextColored(
-                ImVec4(1.0f, 0.30f, 0.90f, 1.0f),
-                "多余方块：%llu",
-                static_cast<unsigned long long>(progress.extra)
-            );
-        }
-        auto const aimedProjectedBlock = place::getAimedProjectedBlockName();
-        if (showProjectedBlockName && !aimedProjectedBlock.empty()) {
-            ImGui::Text("投影方块：%s", aimedProjectedBlock.c_str());
-        }
-        // Record our rect + corner so the material HUD (drawn right after) can
-        // stack clear of us when it shares this corner, instead of overlapping.
-        gProjectionHudLayout.frame = ImGui::GetFrameCount();
-        gProjectionHudLayout.position = hudPosition;
-        gProjectionHudLayout.topY = ImGui::GetWindowPos().y;
-        gProjectionHudLayout.bottomY = ImGui::GetWindowPos().y + ImGui::GetWindowSize().y;
+    auto const showAnyProgress = showOverallProgress || showProgress ||
+                                 showWrongState || showWrongType ||
+                                 showExtraBlocks;
+    projection::BuildProgress progress{};
+    if (showAnyProgress)
+      progress = projection::getBuildProgress();
+    if (showOverallProgress) {
+      ImGui::Text("总体进度：%llu / %llu",
+                  static_cast<unsigned long long>(progress.placed),
+                  static_cast<unsigned long long>(progress.total));
     }
-    ImGui::End();
-    ImGui::PopStyleVar(2);
+    if (showProgress) {
+      ImGui::Text("建造进度：%llu / %llu",
+                  static_cast<unsigned long long>(progress.visiblePlaced),
+                  static_cast<unsigned long long>(progress.visibleTotal));
+    }
+    if (showWrongState && progress.wrongState != 0) {
+      ImGui::TextColored(ImVec4(1.0f, 0.62f, 0.18f, 1.0f), "朝向错误：%llu",
+                         static_cast<unsigned long long>(progress.wrongState));
+    }
+    if (showWrongType && progress.wrongType != 0) {
+      ImGui::TextColored(ImVec4(1.0f, 0.28f, 0.24f, 1.0f), "放置错误：%llu",
+                         static_cast<unsigned long long>(progress.wrongType));
+    }
+    if (showExtraBlocks && progress.extra != 0) {
+      ImGui::TextColored(ImVec4(1.0f, 0.30f, 0.90f, 1.0f), "多余方块：%llu",
+                         static_cast<unsigned long long>(progress.extra));
+    }
+    auto const aimedProjectedBlock = place::getAimedProjectedBlockName();
+    if (showProjectedBlockName && !aimedProjectedBlock.empty()) {
+      ImGui::Text("投影方块：%s", aimedProjectedBlock.c_str());
+    }
+    // Record our rect + corner so the material HUD (drawn right after) can
+    // stack clear of us when it shares this corner, instead of overlapping.
+    gProjectionHudLayout.frame = ImGui::GetFrameCount();
+    gProjectionHudLayout.position = hudPosition;
+    gProjectionHudLayout.topY = ImGui::GetWindowPos().y;
+    gProjectionHudLayout.bottomY =
+        ImGui::GetWindowPos().y + ImGui::GetWindowSize().y;
+  }
+  ImGui::End();
+  ImGui::PopStyleVar(2);
 }
 
 void renderMaterialHud() {
-    if (isGuiVisible()) return;
-    if (!hudContextAvailable()) return;
-    if (!materialHudEnabled()) return;
-    auto const hud = uiState().hud();
-    if (!detail::StructureSession::getInstance().hasLoaded()) return;
-    // Both vectors come from one locked copy so they stay index-aligned. The
-    // tracker publishes only the current visible layer's missing materials;
-    // this present thread performs no structure or inventory scans.
-    auto const snapshot = uiState().materialHudSnapshot();
-    auto const& materials = snapshot.requirements;
-    auto const& available = snapshot.available;
+  if (isGuiVisible())
+    return;
+  if (!hudContextAvailable())
+    return;
+  if (!materialHudEnabled())
+    return;
+  auto const hud = uiState().hud();
+  if (!detail::StructureSession::getInstance().hasLoaded())
+    return;
+  // Both vectors come from one locked copy so they stay index-aligned. The
+  // tracker publishes only the current visible layer's missing materials;
+  // this present thread performs no structure or inventory scans.
+  auto const snapshot = uiState().materialHudSnapshot();
+  auto const &materials = snapshot.requirements;
+  auto const &available = snapshot.available;
 
-    struct Row {
-        std::string const* name;
-        std::uint64_t      missing;
-        int                stackSize;
-    };
-    std::vector<Row> missing;
-    for (std::size_t index = 0; index < materials.size(); ++index) {
-        auto const need = materials[index].count;
-        auto const have = index < available.size() ? available[index] : 0;
-        auto const miss = static_cast<std::uint64_t>(have) >= need
-            ? 0ULL : need - static_cast<std::uint64_t>(have);
-        if (miss > 0) {
-            missing.push_back({&materials[index].displayName, miss, materials[index].stackSize});
-        }
+  struct Row {
+    std::string const *name;
+    std::uint64_t missing;
+    int stackSize;
+  };
+  std::vector<Row> missing;
+  for (std::size_t index = 0; index < materials.size(); ++index) {
+    auto const need = materials[index].count;
+    auto const have = index < available.size() ? available[index] : 0;
+    auto const miss = static_cast<std::uint64_t>(have) >= need
+                          ? 0ULL
+                          : need - static_cast<std::uint64_t>(have);
+    if (miss > 0) {
+      missing.push_back(
+          {&materials[index].displayName, miss, materials[index].stackSize});
     }
-    std::sort(missing.begin(), missing.end(), [](Row const& a, Row const& b) {
-        return a.missing > b.missing;
-    });
+  }
+  std::sort(missing.begin(), missing.end(),
+            [](Row const &a, Row const &b) { return a.missing > b.missing; });
 
-    auto const displaySize = ImGui::GetIO().DisplaySize;
-    float uiScale = hud.uiScale;
-    if (uiScale <= 0.0f) {
-        uiScale = std::clamp(std::min(displaySize.x / 1920.0f, displaySize.y / 1080.0f), 1.0f, 5.0f);
+  auto const displaySize = ImGui::GetIO().DisplaySize;
+  float uiScale = hud.uiScale;
+  if (uiScale <= 0.0f) {
+    uiScale = std::clamp(
+        std::min(displaySize.x / 1920.0f, displaySize.y / 1080.0f), 1.0f, 5.0f);
+  }
+  auto const metrics = lholo::ui::calculateMetrics(displaySize, uiScale);
+  lholo::ui::applyFluentTheme(metrics);
+  auto const margin = metrics.outerPadding;
+  auto const position = std::clamp(materialHudPosition(), 0, 3);
+  bool const right = position >= 2;
+  bool const bottom = (position & 1) != 0;
+  float anchorX = right ? displaySize.x - margin : margin;
+  float anchorY = bottom ? displaySize.y - margin : margin;
+  // When the projection HUD occupies the same corner this frame, stack clear
+  // of it — above it for a bottom corner, below it for a top corner.
+  if (gProjectionHudLayout.frame == ImGui::GetFrameCount() &&
+      gProjectionHudLayout.position == position) {
+    if (bottom) {
+      anchorY = std::min(anchorY, gProjectionHudLayout.topY - metrics.gap);
+    } else {
+      anchorY = std::max(anchorY, gProjectionHudLayout.bottomY + metrics.gap);
     }
-    auto const metrics = lholo::ui::calculateMetrics(displaySize, uiScale);
-    lholo::ui::applyFluentTheme(metrics);
-    auto const margin = metrics.outerPadding;
-    auto const position = std::clamp(materialHudPosition(), 0, 3);
-    bool const right = position >= 2;
-    bool const bottom = (position & 1) != 0;
-    float anchorX = right ? displaySize.x - margin : margin;
-    float anchorY = bottom ? displaySize.y - margin : margin;
-    // When the projection HUD occupies the same corner this frame, stack clear
-    // of it — above it for a bottom corner, below it for a top corner.
-    if (gProjectionHudLayout.frame == ImGui::GetFrameCount()
-        && gProjectionHudLayout.position == position) {
-        if (bottom) {
-            anchorY = std::min(anchorY, gProjectionHudLayout.topY - metrics.gap);
-        } else {
-            anchorY = std::max(anchorY, gProjectionHudLayout.bottomY + metrics.gap);
-        }
+  }
+  ImGui::SetNextWindowPos(ImVec2(anchorX, anchorY), ImGuiCond_Always,
+                          ImVec2(right ? 1.0f : 0.0f, bottom ? 1.0f : 0.0f));
+  ImGui::SetNextWindowBgAlpha(0.68f);
+  ImGui::PushStyleVar(ImGuiStyleVar_WindowRounding, metrics.rounding * 0.7f);
+  ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding,
+                      ImVec2(metrics.sectionPadding, metrics.gap));
+  constexpr auto flags =
+      ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_AlwaysAutoResize |
+      ImGuiWindowFlags_NoSavedSettings | ImGuiWindowFlags_NoFocusOnAppearing |
+      ImGuiWindowFlags_NoBringToFrontOnFocus | ImGuiWindowFlags_NoNavInputs |
+      ImGuiWindowFlags_NoNavFocus | ImGuiWindowFlags_NoInputs;
+  if (ImGui::Begin("##LHoloMaterialHud", nullptr, flags)) {
+    ImGui::TextUnformatted("缺失材料");
+    ImGui::Separator();
+    if (!snapshot.ready) {
+      ImGui::TextDisabled("正在统计当前显示范围…");
+    } else if (missing.empty()) {
+      ImGui::TextColored(ImVec4(0.55f, 0.85f, 0.40f, 1.0f),
+                         "当前显示范围材料已备齐 ✓");
+    } else {
+      constexpr std::size_t kMaxRows = 14;
+      for (std::size_t index = 0; index < missing.size() && index < kMaxRows;
+           ++index) {
+        auto const &row = missing[index];
+        // JE Litematica style: name then the missing amount broken into
+        // stacks, e.g. "白色玻璃  111 (1 x 64 + 47)".
+        ImGui::TextColored(
+            ImVec4(1.0f, 0.62f, 0.20f, 1.0f), "%s  %s", row.name->c_str(),
+            lholo::ui::formatStackCount(row.missing, row.stackSize).c_str());
+      }
+      if (missing.size() > kMaxRows) {
+        ImGui::TextDisabled("…还有 %zu 种材料", missing.size() - kMaxRows);
+      }
     }
-    ImGui::SetNextWindowPos(
-        ImVec2(anchorX, anchorY), ImGuiCond_Always, ImVec2(right ? 1.0f : 0.0f, bottom ? 1.0f : 0.0f)
-    );
-    ImGui::SetNextWindowBgAlpha(0.68f);
-    ImGui::PushStyleVar(ImGuiStyleVar_WindowRounding, metrics.rounding * 0.7f);
-    ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, ImVec2(metrics.sectionPadding, metrics.gap));
-    constexpr auto flags = ImGuiWindowFlags_NoDecoration
-        | ImGuiWindowFlags_AlwaysAutoResize
-        | ImGuiWindowFlags_NoSavedSettings
-        | ImGuiWindowFlags_NoFocusOnAppearing
-        | ImGuiWindowFlags_NoBringToFrontOnFocus
-        | ImGuiWindowFlags_NoNavInputs
-        | ImGuiWindowFlags_NoNavFocus
-        | ImGuiWindowFlags_NoInputs;
-    if (ImGui::Begin("##LHoloMaterialHud", nullptr, flags)) {
-        ImGui::TextUnformatted("缺失材料");
-        ImGui::Separator();
-        if (!snapshot.ready) {
-            ImGui::TextDisabled("正在统计当前显示范围…");
-        } else if (missing.empty()) {
-            ImGui::TextColored(
-                ImVec4(0.55f, 0.85f, 0.40f, 1.0f), "当前显示范围材料已备齐 ✓"
-            );
-        } else {
-            constexpr std::size_t kMaxRows = 14;
-            for (std::size_t index = 0; index < missing.size() && index < kMaxRows; ++index) {
-                auto const& row = missing[index];
-                // JE Litematica style: name then the missing amount broken into
-                // stacks, e.g. "白色玻璃  111 (1 x 64 + 47)".
-                ImGui::TextColored(
-                    ImVec4(1.0f, 0.62f, 0.20f, 1.0f), "%s  %s",
-                    row.name->c_str(),
-                    lholo::ui::formatStackCount(row.missing, row.stackSize).c_str()
-                );
-            }
-            if (missing.size() > kMaxRows) {
-                ImGui::TextDisabled("…还有 %zu 种材料", missing.size() - kMaxRows);
-            }
-        }
-    }
-    ImGui::End();
-    ImGui::PopStyleVar(2);
+  }
+  ImGui::End();
+  ImGui::PopStyleVar(2);
 }
 
-void renderGui() {
-    lholo::ui::renderStructureMenu();
-}
+void renderGui() { lholo::ui::renderStructureMenu(); }
 
 void loadSettings() {
-    auto const path = settingsPath();
-    try {
-        auto& session = detail::StructureSession::getInstance();
-        lholo::settings::Settings settings;
-        if (!lholo::settings::loadSettingsFile(path, settings)) {
-            saveSettings();
-            return;
-        }
-        session.setLastPath(settings.lastStructurePath);
-        uiState().setUiScale(std::clamp(settings.uiScale, 0.0f, 5.0f));
-        projection::setOpacity(settings.opacity);
-        projection::setCorrectionFillOpacity(settings.correctionFillOpacity);
-        projection::setCorrectionOutlineOpacity(settings.correctionOutlineOpacity);
-        projection::setStructureBoundsEnabled(settings.structureBoundsEnabled);
-        projection::setCorrectionSeeThrough(settings.correctionSeeThrough);
-        projection::setMissingSeeThrough(settings.missingSeeThrough);
-        setExperimentalConsentGiven(settings.experimentalConsent);
-        setMaterialHudEnabled(settings.materialHudEnabled);
-        setMaterialHudPosition(settings.materialHudPosition);
-        // Transform and layer state are session-local. Only the explicit
-        // "restore last projection" record below is persisted.
-        session.resetTransform();
-        auto hud = uiState().hud();
-        hud.enabled = settings.hudEnabled;
-        hud.showFileName = settings.hudShowFileName;
-        hud.showLayer = settings.hudShowLayer;
-        hud.showOverallProgress = settings.hudShowOverallProgress;
-        hud.showProgress = settings.hudShowProgress;
-        hud.showWrongState = settings.hudShowWrongState;
-        hud.showWrongType = settings.hudShowWrongType;
-        hud.showExtraBlocks = settings.hudShowExtraBlocks;
-        hud.showProjectedBlockName = settings.hudShowProjectedBlockName;
-        hud.position = std::clamp(settings.hudPosition, 0, 3);
-        uiState().applyHud(hud);
-        // Assisted-placement modes are intentionally session-only. Ignore
-        // legacy persisted values and always begin a new game session disabled.
-        place::setEnabled(false);
-        place::setManualMode(false);
-        place::setRangeEnabled(false);
-        place::setPlacementRadius(std::clamp(settings.placementRadius, 1, 4));
-        place::setAutoPlacementBreakCooldownSeconds(
-            std::clamp(settings.autoPlacementBreakCooldownSeconds, 0, 60)
-        );
-        uiState().setHotkey(
-            kGuiHotkeyIndex,
-            std::clamp(settings.guiHotkey, 0, 255),
-            std::clamp(settings.guiHotkeyModifiers, 0, 7)
-        );
-        uiState().setHotkey(
-            kLayerIncreaseHotkeyIndex,
-            std::clamp(settings.layerIncreaseHotkey, 0, 255),
-            std::clamp(settings.layerIncreaseHotkeyModifiers, 0, 7)
-        );
-        uiState().setHotkey(
-            kLayerDecreaseHotkeyIndex,
-            std::clamp(settings.layerDecreaseHotkey, 0, 255),
-            std::clamp(settings.layerDecreaseHotkeyModifiers, 0, 7)
-        );
-        for (std::size_t index = 0; index < input::kMoveHotkeyCount; ++index) {
-            uiState().setHotkey(
-                index + input::kMoveHotkeyFirst,
-                std::clamp(settings.moveHotkeys[index], 0, 255),
-                std::clamp(settings.moveHotkeyModifiers[index], 0, 7)
-            );
-        }
-        uiState().setHotkey(
-            kLoadProjectionHotkeyIndex,
-            std::clamp(settings.loadProjectionHotkey, 0, 255),
-            std::clamp(settings.loadProjectionHotkeyModifiers, 0, 7)
-        );
-        uiState().setHotkey(
-            kCloseProjectionHotkeyIndex,
-            std::clamp(settings.closeProjectionHotkey, 0, 255),
-            std::clamp(settings.closeProjectionHotkeyModifiers, 0, 7)
-        );
-        session.setSavedProjection({
-            settings.hasSavedProjection,
-            settings.savedAnchorX,
-            settings.savedAnchorY,
-            settings.savedAnchorZ,
-            {
-                settings.savedRotation,
-                std::clamp(settings.savedMirror, 0, 2),
-                settings.savedOffsetX,
-                settings.savedOffsetY,
-                settings.savedOffsetZ,
-                settings.savedLayerDisplayMode,
-                settings.savedDisplayLayer,
-                std::clamp(settings.savedLayerAxis, 0, 1)
-            },
-            settings.savedStructurePath
-        });
-        logger().info("Loaded projection settings from {}", path.string());
-    } catch (std::exception const& exception) {
-        logger().error("Could not load projection settings {}: {}", path.string(), exception.what());
+  auto const path = settingsPath();
+  try {
+    auto &session = detail::StructureSession::getInstance();
+    lholo::settings::Settings settings;
+    if (!lholo::settings::loadSettingsFile(path, settings)) {
+      saveSettings();
+      return;
     }
+    session.setLastPath(settings.lastStructurePath);
+    uiState().setUiScale(std::clamp(settings.uiScale, 0.0f, 5.0f));
+    projection::setOpacity(settings.opacity);
+    projection::setCorrectionFillOpacity(settings.correctionFillOpacity);
+    projection::setCorrectionOutlineOpacity(settings.correctionOutlineOpacity);
+    projection::setStructureBoundsEnabled(settings.structureBoundsEnabled);
+    projection::setCorrectionSeeThrough(settings.correctionSeeThrough);
+    projection::setMissingSeeThrough(settings.missingSeeThrough);
+    setExperimentalConsentGiven(settings.experimentalConsent);
+    setMaterialHudEnabled(settings.materialHudEnabled);
+    setMaterialHudPosition(settings.materialHudPosition);
+    // Transform and layer state are session-local. Only the explicit
+    // "restore last projection" record below is persisted.
+    session.resetTransform();
+    auto hud = uiState().hud();
+    hud.enabled = settings.hudEnabled;
+    hud.showFileName = settings.hudShowFileName;
+    hud.showLayer = settings.hudShowLayer;
+    hud.showOverallProgress = settings.hudShowOverallProgress;
+    hud.showProgress = settings.hudShowProgress;
+    hud.showWrongState = settings.hudShowWrongState;
+    hud.showWrongType = settings.hudShowWrongType;
+    hud.showExtraBlocks = settings.hudShowExtraBlocks;
+    hud.showProjectedBlockName = settings.hudShowProjectedBlockName;
+    hud.position = std::clamp(settings.hudPosition, 0, 3);
+    uiState().applyHud(hud);
+    // Assisted-placement modes are intentionally session-only. Ignore
+    // legacy persisted values and always begin a new game session disabled.
+    place::setEnabled(false);
+    place::setManualMode(false);
+    place::setRangeEnabled(false);
+    place::setPlacementRadius(std::clamp(settings.placementRadius, 1, 4));
+    place::setAutoPlacementBreakCooldownSeconds(
+        std::clamp(settings.autoPlacementBreakCooldownSeconds, 0, 60));
+    uiState().setHotkey(kGuiHotkeyIndex, std::clamp(settings.guiHotkey, 0, 255),
+                        std::clamp(settings.guiHotkeyModifiers, 0, 7));
+    uiState().setHotkey(
+        kStructureOffsetHotkeyIndex,
+        std::clamp(settings.structureOffsetHotkey, 0, 255),
+        std::clamp(settings.structureOffsetHotkeyModifiers, 0, 7));
+    uiState().setHotkey(
+        kLayerIncreaseHotkeyIndex,
+        std::clamp(settings.layerIncreaseHotkey, 0, 255),
+        std::clamp(settings.layerIncreaseHotkeyModifiers, 0, 7));
+    uiState().setHotkey(
+        kLayerDecreaseHotkeyIndex,
+        std::clamp(settings.layerDecreaseHotkey, 0, 255),
+        std::clamp(settings.layerDecreaseHotkeyModifiers, 0, 7));
+    for (std::size_t index = 0; index < input::kMoveHotkeyCount; ++index) {
+      uiState().setHotkey(
+          index + input::kMoveHotkeyFirst,
+          std::clamp(settings.moveHotkeys[index], 0, 255),
+          std::clamp(settings.moveHotkeyModifiers[index], 0, 7));
+    }
+    uiState().setHotkey(
+        kLoadProjectionHotkeyIndex,
+        std::clamp(settings.loadProjectionHotkey, 0, 255),
+        std::clamp(settings.loadProjectionHotkeyModifiers, 0, 7));
+    uiState().setHotkey(
+        kCloseProjectionHotkeyIndex,
+        std::clamp(settings.closeProjectionHotkey, 0, 255),
+        std::clamp(settings.closeProjectionHotkeyModifiers, 0, 7));
+    session.setSavedProjection(
+        {settings.hasSavedProjection,
+         settings.savedAnchorX,
+         settings.savedAnchorY,
+         settings.savedAnchorZ,
+         {settings.savedRotation, std::clamp(settings.savedMirror, 0, 2),
+          settings.savedOffsetX, settings.savedOffsetY, settings.savedOffsetZ,
+          settings.savedLayerDisplayMode, settings.savedDisplayLayer,
+          std::clamp(settings.savedLayerAxis, 0, 1)},
+         settings.savedStructurePath});
+    logger().info("Loaded projection settings from {}", path.string());
+  } catch (std::exception const &exception) {
+    logger().error("Could not load projection settings {}: {}", path.string(),
+                   exception.what());
+  }
 }
 
 void saveSettings() {
-    auto const path = settingsPath();
-    try {
-        auto& session = detail::StructureSession::getInstance();
-        // Only an active projection may update its restore snapshot. At
-        // startup the session-local transform/layer values intentionally
-        // reset to defaults; copying those values before the user restores
-        // a structure would silently destroy the saved state.
-        session.refreshSavedTransformIfActive();
-        auto const sessionSnapshot = session.snapshot();
-        auto const hud = uiState().hud();
-        lholo::settings::Settings settings;
-        settings.lastStructurePath = sessionSnapshot.lastPath;
-        settings.uiScale = hud.uiScale;
-        settings.opacity = projection::getOpacity();
-        settings.correctionFillOpacity = projection::getCorrectionFillOpacity();
-        settings.correctionOutlineOpacity = projection::getCorrectionOutlineOpacity();
-        settings.structureBoundsEnabled = projection::getStructureBoundsEnabled();
-        settings.correctionSeeThrough = projection::getCorrectionSeeThrough();
-        settings.missingSeeThrough = projection::getMissingSeeThrough();
-        settings.experimentalConsent = experimentalConsentGiven();
-        settings.materialHudEnabled = materialHudEnabled();
-        settings.materialHudPosition = materialHudPosition();
-        settings.placementRadius = place::getPlacementRadius();
-        settings.autoPlacementBreakCooldownSeconds
-            = place::getAutoPlacementBreakCooldownSeconds();
-        settings.hudEnabled = hud.enabled;
-        settings.hudShowFileName = hud.showFileName;
-        settings.hudShowLayer = hud.showLayer;
-        settings.hudShowOverallProgress = hud.showOverallProgress;
-        settings.hudShowProgress = hud.showProgress;
-        settings.hudShowWrongState = hud.showWrongState;
-        settings.hudShowWrongType = hud.showWrongType;
-        settings.hudShowExtraBlocks = hud.showExtraBlocks;
-        settings.hudShowProjectedBlockName = hud.showProjectedBlockName;
-        settings.hudPosition = hud.position;
-        auto const guiHotkey = uiState().hotkey(kGuiHotkeyIndex);
-        auto const layerIncreaseHotkey = uiState().hotkey(kLayerIncreaseHotkeyIndex);
-        auto const layerDecreaseHotkey = uiState().hotkey(kLayerDecreaseHotkeyIndex);
-        settings.guiHotkey = guiHotkey.key;
-        settings.guiHotkeyModifiers = guiHotkey.modifiers;
-        settings.layerIncreaseHotkey = layerIncreaseHotkey.key;
-        settings.layerDecreaseHotkey = layerDecreaseHotkey.key;
-        settings.layerIncreaseHotkeyModifiers = layerIncreaseHotkey.modifiers;
-        settings.layerDecreaseHotkeyModifiers = layerDecreaseHotkey.modifiers;
-        for (std::size_t index = 0; index < settings.moveHotkeys.size(); ++index) {
-            auto const moveHotkey = uiState().hotkey(index + input::kMoveHotkeyFirst);
-            settings.moveHotkeys[index] = moveHotkey.key;
-            settings.moveHotkeyModifiers[index] = moveHotkey.modifiers;
-        }
-        auto const loadProjectionHotkey = uiState().hotkey(kLoadProjectionHotkeyIndex);
-        auto const closeProjectionHotkey = uiState().hotkey(kCloseProjectionHotkeyIndex);
-        settings.loadProjectionHotkey = loadProjectionHotkey.key;
-        settings.loadProjectionHotkeyModifiers = loadProjectionHotkey.modifiers;
-        settings.closeProjectionHotkey = closeProjectionHotkey.key;
-        settings.closeProjectionHotkeyModifiers = closeProjectionHotkey.modifiers;
-        settings.hasSavedProjection = sessionSnapshot.saved.available;
-        settings.savedAnchorX = sessionSnapshot.saved.anchorX;
-        settings.savedAnchorY = sessionSnapshot.saved.anchorY;
-        settings.savedAnchorZ = sessionSnapshot.saved.anchorZ;
-        settings.savedRotation = sessionSnapshot.saved.transform.rotation;
-        settings.savedMirror = sessionSnapshot.saved.transform.mirror;
-        settings.savedOffsetX = sessionSnapshot.saved.transform.offsetX;
-        settings.savedOffsetY = sessionSnapshot.saved.transform.offsetY;
-        settings.savedOffsetZ = sessionSnapshot.saved.transform.offsetZ;
-        settings.savedLayerDisplayMode = sessionSnapshot.saved.transform.layerDisplayMode;
-        settings.savedDisplayLayer = sessionSnapshot.saved.transform.displayLayer;
-        settings.savedLayerAxis = sessionSnapshot.saved.transform.layerAxis;
-        settings.savedStructurePath = sessionSnapshot.saved.structurePath;
-        lholo::settings::saveSettingsFile(path, settings);
-    } catch (std::exception const& exception) {
-        logger().error("Could not save projection settings {}: {}", path.string(), exception.what());
+  auto const path = settingsPath();
+  try {
+    auto &session = detail::StructureSession::getInstance();
+    // Only an active projection may update its restore snapshot. At
+    // startup the session-local transform/layer values intentionally
+    // reset to defaults; copying those values before the user restores
+    // a structure would silently destroy the saved state.
+    session.refreshSavedTransformIfActive();
+    auto const sessionSnapshot = session.snapshot();
+    auto const hud = uiState().hud();
+    lholo::settings::Settings settings;
+    settings.lastStructurePath = sessionSnapshot.lastPath;
+    settings.uiScale = hud.uiScale;
+    settings.opacity = projection::getOpacity();
+    settings.correctionFillOpacity = projection::getCorrectionFillOpacity();
+    settings.correctionOutlineOpacity =
+        projection::getCorrectionOutlineOpacity();
+    settings.structureBoundsEnabled = projection::getStructureBoundsEnabled();
+    settings.correctionSeeThrough = projection::getCorrectionSeeThrough();
+    settings.missingSeeThrough = projection::getMissingSeeThrough();
+    settings.experimentalConsent = experimentalConsentGiven();
+    settings.materialHudEnabled = materialHudEnabled();
+    settings.materialHudPosition = materialHudPosition();
+    settings.placementRadius = place::getPlacementRadius();
+    settings.autoPlacementBreakCooldownSeconds =
+        place::getAutoPlacementBreakCooldownSeconds();
+    settings.hudEnabled = hud.enabled;
+    settings.hudShowFileName = hud.showFileName;
+    settings.hudShowLayer = hud.showLayer;
+    settings.hudShowOverallProgress = hud.showOverallProgress;
+    settings.hudShowProgress = hud.showProgress;
+    settings.hudShowWrongState = hud.showWrongState;
+    settings.hudShowWrongType = hud.showWrongType;
+    settings.hudShowExtraBlocks = hud.showExtraBlocks;
+    settings.hudShowProjectedBlockName = hud.showProjectedBlockName;
+    settings.hudPosition = hud.position;
+    auto const guiHotkey = uiState().hotkey(kGuiHotkeyIndex);
+    auto const structureOffsetHotkey =
+        uiState().hotkey(kStructureOffsetHotkeyIndex);
+    auto const layerIncreaseHotkey =
+        uiState().hotkey(kLayerIncreaseHotkeyIndex);
+    auto const layerDecreaseHotkey =
+        uiState().hotkey(kLayerDecreaseHotkeyIndex);
+    settings.guiHotkey = guiHotkey.key;
+    settings.guiHotkeyModifiers = guiHotkey.modifiers;
+    settings.structureOffsetHotkey = structureOffsetHotkey.key;
+    settings.structureOffsetHotkeyModifiers = structureOffsetHotkey.modifiers;
+    settings.layerIncreaseHotkey = layerIncreaseHotkey.key;
+    settings.layerDecreaseHotkey = layerDecreaseHotkey.key;
+    settings.layerIncreaseHotkeyModifiers = layerIncreaseHotkey.modifiers;
+    settings.layerDecreaseHotkeyModifiers = layerDecreaseHotkey.modifiers;
+    for (std::size_t index = 0; index < settings.moveHotkeys.size(); ++index) {
+      auto const moveHotkey = uiState().hotkey(index + input::kMoveHotkeyFirst);
+      settings.moveHotkeys[index] = moveHotkey.key;
+      settings.moveHotkeyModifiers[index] = moveHotkey.modifiers;
     }
+    auto const loadProjectionHotkey =
+        uiState().hotkey(kLoadProjectionHotkeyIndex);
+    auto const closeProjectionHotkey =
+        uiState().hotkey(kCloseProjectionHotkeyIndex);
+    settings.loadProjectionHotkey = loadProjectionHotkey.key;
+    settings.loadProjectionHotkeyModifiers = loadProjectionHotkey.modifiers;
+    settings.closeProjectionHotkey = closeProjectionHotkey.key;
+    settings.closeProjectionHotkeyModifiers = closeProjectionHotkey.modifiers;
+    settings.hasSavedProjection = sessionSnapshot.saved.available;
+    settings.savedAnchorX = sessionSnapshot.saved.anchorX;
+    settings.savedAnchorY = sessionSnapshot.saved.anchorY;
+    settings.savedAnchorZ = sessionSnapshot.saved.anchorZ;
+    settings.savedRotation = sessionSnapshot.saved.transform.rotation;
+    settings.savedMirror = sessionSnapshot.saved.transform.mirror;
+    settings.savedOffsetX = sessionSnapshot.saved.transform.offsetX;
+    settings.savedOffsetY = sessionSnapshot.saved.transform.offsetY;
+    settings.savedOffsetZ = sessionSnapshot.saved.transform.offsetZ;
+    settings.savedLayerDisplayMode =
+        sessionSnapshot.saved.transform.layerDisplayMode;
+    settings.savedDisplayLayer = sessionSnapshot.saved.transform.displayLayer;
+    settings.savedLayerAxis = sessionSnapshot.saved.transform.layerAxis;
+    settings.savedStructurePath = sessionSnapshot.saved.structurePath;
+    lholo::settings::saveSettingsFile(path, settings);
+  } catch (std::exception const &exception) {
+    logger().error("Could not save projection settings {}: {}", path.string(),
+                   exception.what());
+  }
 }
 
 std::shared_ptr<LoadedStructure const> getLoaded() {
-    return detail::StructureSession::getInstance().loaded();
+  return detail::StructureSession::getInstance().loaded();
 }
 
 int getRotationQuarterTurns() {
-    return detail::StructureSession::getInstance().transform().rotation;
+  return detail::StructureSession::getInstance().transform().rotation;
 }
 
 int getMirrorMode() {
-    return std::clamp(detail::StructureSession::getInstance().transform().mirror, 0, 2);
+  return std::clamp(detail::StructureSession::getInstance().transform().mirror,
+                    0, 2);
 }
 
-int getOffsetX() { return detail::StructureSession::getInstance().transform().offsetX; }
-int getOffsetY() { return detail::StructureSession::getInstance().transform().offsetY; }
-int getOffsetZ() { return detail::StructureSession::getInstance().transform().offsetZ; }
-int getLayerDisplayMode() { return detail::StructureSession::getInstance().transform().layerDisplayMode; }
-int getDisplayLayer() { return detail::StructureSession::getInstance().transform().displayLayer; }
-int getLayerAxis() { return detail::StructureSession::getInstance().transform().layerAxis; }
+int getOffsetX() {
+  return detail::StructureSession::getInstance().transform().offsetX;
+}
+int getOffsetY() {
+  return detail::StructureSession::getInstance().transform().offsetY;
+}
+int getOffsetZ() {
+  return detail::StructureSession::getInstance().transform().offsetZ;
+}
+int getLayerDisplayMode() {
+  return detail::StructureSession::getInstance().transform().layerDisplayMode;
+}
+int getDisplayLayer() {
+  return detail::StructureSession::getInstance().transform().displayLayer;
+}
+int getLayerAxis() {
+  return detail::StructureSession::getInstance().transform().layerAxis;
+}
 
 void recordProjectionAnchor(int x, int y, int z) {
-    detail::StructureSession::getInstance().recordProjectionAnchor(x, y, z);
-    saveSettings();
+  detail::StructureSession::getInstance().recordProjectionAnchor(x, y, z);
+  saveSettings();
 }
 
 void restoreSavedProjection() {
-    auto& session = detail::StructureSession::getInstance();
-    auto const saved = session.savedProjection();
-    auto const& savedPath = saved.structurePath;
-    std::string error;
-    auto loaded = detail::loadStructureFile(detail::pathFromUtf8(savedPath), error);
-    if (!loaded) {
-        session.setStatus("恢复失败: " + error);
-        logger().error("Could not restore structure {}: {}", savedPath, error);
-        return;
-    }
-    session.setRotation(saved.transform.rotation);
-    session.setMirror(std::clamp(saved.transform.mirror, 0, 2));
-    session.setOffsetX(saved.transform.offsetX);
-    session.setOffsetY(saved.transform.offsetY);
-    session.setOffsetZ(saved.transform.offsetZ);
-    session.setLayerDisplayMode(saved.transform.layerDisplayMode);
-    session.setDisplayLayer(saved.transform.displayLayer);
-    session.setLayerAxis(saved.transform.layerAxis);
-    projection::requestNextStructureAnchor(saved.anchorX, saved.anchorY, saved.anchorZ);
-    session.replaceLoaded(std::move(loaded), savedPath, "已恢复上次投影记录，等待进入渲染");
-    detail::invalidateMaterialList();
-    logger().info(
-        "Restoring projection {} at ({}, {}, {})",
-        savedPath, saved.anchorX, saved.anchorY, saved.anchorZ
-    );
+  auto &session = detail::StructureSession::getInstance();
+  auto const saved = session.savedProjection();
+  auto const &savedPath = saved.structurePath;
+  std::string error;
+  auto loaded =
+      detail::loadStructureFile(detail::pathFromUtf8(savedPath), error);
+  if (!loaded) {
+    session.setStatus("恢复失败: " + error);
+    logger().error("Could not restore structure {}: {}", savedPath, error);
+    return;
+  }
+  session.setRotation(saved.transform.rotation);
+  session.setMirror(std::clamp(saved.transform.mirror, 0, 2));
+  session.setOffsetX(saved.transform.offsetX);
+  session.setOffsetY(saved.transform.offsetY);
+  session.setOffsetZ(saved.transform.offsetZ);
+  session.setLayerDisplayMode(saved.transform.layerDisplayMode);
+  session.setDisplayLayer(saved.transform.displayLayer);
+  session.setLayerAxis(saved.transform.layerAxis);
+  projection::requestNextStructureAnchor(saved.anchorX, saved.anchorY,
+                                         saved.anchorZ);
+  session.replaceLoaded(std::move(loaded), savedPath,
+                        "已恢复上次投影记录，等待进入渲染");
+  detail::invalidateMaterialList();
+  logger().info("Restoring projection {} at ({}, {}, {})", savedPath,
+                saved.anchorX, saved.anchorY, saved.anchorZ);
 }
 
 namespace {
 
 void clearProjectionSession(std::string status) {
-    // Withdraw the requested structure before waiting for the mesh worker.
-    // Otherwise the render hook can observe the old loaded structure in the gap after
-    // projection::disable() and immediately enable the projection again.
-    detail::StructureSession::getInstance().clearLoaded(std::move(status));
+  // Withdraw the requested structure before waiting for the mesh worker.
+  // Otherwise the render hook can observe the old loaded structure in the gap
+  // after projection::disable() and immediately enable the projection again.
+  detail::StructureSession::getInstance().clearLoaded(std::move(status));
 
-    // The active projection and in-flight worker keep non-owning Block pointers
-    // into the Java mapper registry. Stop them before releasing that registry.
-    projection::disable();
-    resetJavaBlockMappingCache();
+  // The active projection and in-flight worker keep non-owning Block pointers
+  // into the Java mapper registry. Stop them before releasing that registry.
+  projection::disable();
+  resetJavaBlockMappingCache();
 }
 
 void resetWorldSession() {
-    clearProjectionSession("已退出世界");
-    uiState().resetWorldSession();
+  clearProjectionSession("已退出世界");
+  uiState().resetWorldSession();
 }
 
 } // namespace
 
 void clear() {
-    clearProjectionSession("已关闭投影");
-    uiState().clearMaterials();
+  clearProjectionSession("已关闭投影");
+  uiState().clearMaterials();
 }
 
 } // namespace lholo::structure

--- a/src/structure/StructureLoader.h
+++ b/src/structure/StructureLoader.h
@@ -16,6 +16,8 @@
 
 #pragma once
 
+#include <algorithm>
+#include <cmath>
 #include <cstdint>
 #include <filesystem>
 #include <memory>
@@ -31,38 +33,80 @@ namespace lholo::structure {
 inline constexpr std::uint64_t kProjectionLifecycleHintDurationMs = 2500;
 
 struct LoadedStructure {
-    struct RegionBox {
-        int x{};
-        int y{};
-        int z{};
-        int sizeX{};
-        int sizeY{};
-        int sizeZ{};
-    };
+  struct RegionBox {
+    int x{};
+    int y{};
+    int z{};
+    int sizeX{};
+    int sizeY{};
+    int sizeZ{};
+  };
 
-    std::filesystem::path                 sourcePath;
-    int                                  sizeX{};
-    int                                  sizeY{};
-    int                                  sizeZ{};
-    std::uint64_t                        volume{};
-    std::uint64_t                        primaryBlocks{};
-    std::uint64_t                        secondaryBlocks{};
-    std::uint64_t                        paletteEntries{};
-    std::uint64_t                        generation{};
-    // Cells covered by the source format. mcstructure contributes one box;
-    // litematic contributes one per region so gaps between regions are not
-    // mistaken for schematic air by projection correction.
-    std::vector<RegionBox>               regions;
-    struct RenderBlock {
-        int          x{};
-        int          y{};
-        int          z{};
-        Block const* block{};
-        Block const* liquid{};
-        std::shared_ptr<CompoundTag const> blockEntityNbt;
-    };
-    std::vector<RenderBlock>              renderBlocks;
+  std::filesystem::path sourcePath;
+  int sizeX{};
+  int sizeY{};
+  int sizeZ{};
+  std::uint64_t volume{};
+  std::uint64_t primaryBlocks{};
+  std::uint64_t secondaryBlocks{};
+  std::uint64_t paletteEntries{};
+  std::uint64_t generation{};
+  // Cells covered by the source format. mcstructure contributes one box;
+  // litematic contributes one per region so gaps between regions are not
+  // mistaken for schematic air by projection correction.
+  std::vector<RegionBox> regions;
+  struct RenderBlock {
+    int x{};
+    int y{};
+    int z{};
+    Block const *block{};
+    Block const *liquid{};
+    std::shared_ptr<CompoundTag const> blockEntityNbt;
+  };
+  std::vector<RenderBlock> renderBlocks;
 };
+
+bool computeRelativeOffsetFromView(float forwardX, float forwardY,
+                                   float forwardZ, int wheelDelta, int &offsetX,
+                                   int &offsetY, int &offsetZ);
+bool handleMouseWheelDelta(int wheelDelta);
+
+inline bool computeRelativeOffsetFromView(float forwardX, float forwardY,
+                                          float forwardZ, int wheelDelta,
+                                          int &offsetX, int &offsetY,
+                                          int &offsetZ) {
+  offsetX = 0;
+  offsetY = 0;
+  offsetZ = 0;
+  if (wheelDelta == 0)
+    return false;
+
+  int constexpr kWheelStep = 120;
+  int const steps = std::max(1, std::abs(wheelDelta) / kWheelStep);
+  int const direction = wheelDelta > 0 ? 1 : -1;
+
+  // Use a single axis per wheel gesture: if the view is pitched up or down
+  // enough, keep the vertical move; otherwise keep the planar forward/backward
+  // shift. This prevents horizontal and vertical offset from being applied
+  // simultaneously to the same roll event.
+  float const pitchMagnitude = std::abs(forwardY);
+  float const planarMagnitude =
+      std::max(std::abs(forwardX), std::abs(forwardZ));
+  if (pitchMagnitude >= planarMagnitude && pitchMagnitude > 0.0f) {
+    offsetY = direction * steps * (forwardY >= 0.0f ? 1 : -1);
+    return offsetY != 0;
+  }
+
+  float const horizontalLength = std::hypot(forwardX, forwardZ);
+  if (horizontalLength <= 0.0f)
+    return false;
+
+  float const dx = forwardX / horizontalLength;
+  float const dz = forwardZ / horizontalLength;
+  offsetX = static_cast<int>(std::round(dx * direction * steps));
+  offsetZ = static_cast<int>(std::round(dz * direction * steps));
+  return offsetX != 0 || offsetZ != 0;
+}
 
 void requestOpenGui();
 bool isGuiVisible();
@@ -90,8 +134,8 @@ void renderActionHint();
 // True while a hint is still on screen, so the overlay keeps drawing even with
 // no projection loaded and the menu closed.
 bool actionHintActive();
-// One-time consent for the experimental assisted-placement features (they may be
-// flagged as cheating by server anti-cheat). Persisted once acknowledged.
+// One-time consent for the experimental assisted-placement features (they may
+// be flagged as cheating by server anti-cheat). Persisted once acknowledged.
 bool experimentalConsentGiven();
 void setExperimentalConsentGiven(bool given);
 // Opt-in on-screen material-progress HUD, configured on the HUD settings page
@@ -100,7 +144,7 @@ bool materialHudEnabled();
 void setMaterialHudEnabled(bool enabled);
 // Material HUD corner: 0 top-left, 1 bottom-left, 2 top-right, 3 bottom-right
 // (same encoding as the projection HUD position). Default 3.
-int  materialHudPosition();
+int materialHudPosition();
 void setMaterialHudPosition(int position);
 void renderGui();
 void requestMaterialList();

--- a/src/structure/StructureUiState.cpp
+++ b/src/structure/StructureUiState.cpp
@@ -13,434 +13,521 @@
 namespace lholo::structure::detail {
 namespace {
 
-template <class T>
-bool updateRelaxed(std::atomic<T>& target, T value) {
-    if (target.load(std::memory_order_relaxed) == value) return false;
-    target.store(value, std::memory_order_relaxed);
-    return true;
+template <class T> bool updateRelaxed(std::atomic<T> &target, T value) {
+  if (target.load(std::memory_order_relaxed) == value)
+    return false;
+  target.store(value, std::memory_order_relaxed);
+  return true;
 }
 
 struct DefaultHotkey {
-    unsigned int key;
-    unsigned int modifiers;
+  unsigned int key;
+  unsigned int modifiers;
 };
 
 constexpr std::array<DefaultHotkey, input::kHotkeyCount> kDefaultHotkeys{{
-    {'M',     lholo::ui::kHotkeyModifierAlt},
+    {'M', lholo::ui::kHotkeyModifierAlt},
+    {VK_LMENU, 0u},
     {VK_LEFT, lholo::ui::kHotkeyModifierControl},
-    {VK_RIGHT,lholo::ui::kHotkeyModifierControl},
-    {VK_UP,   lholo::ui::kHotkeyModifierControl},
+    {VK_RIGHT, lholo::ui::kHotkeyModifierControl},
+    {VK_UP, lholo::ui::kHotkeyModifierControl},
     {VK_DOWN, lholo::ui::kHotkeyModifierControl},
-    {VK_UP,   lholo::ui::kHotkeyModifierShift},
+    {VK_UP, lholo::ui::kHotkeyModifierShift},
     {VK_DOWN, lholo::ui::kHotkeyModifierShift},
-    {VK_UP,   lholo::ui::kHotkeyModifierAlt},
+    {VK_UP, lholo::ui::kHotkeyModifierAlt},
     {VK_DOWN, lholo::ui::kHotkeyModifierAlt},
-    {0,       0},
-    {0,       0},
+    {0, 0},
+    {0, 0},
 }};
 
 } // namespace
 
 StructureUiState::StructureUiState() {
-    for (std::size_t index = 0; index < mHotkeys.size(); ++index) {
-        mHotkeys[index].key.store(kDefaultHotkeys[index].key, std::memory_order_relaxed);
-        mHotkeys[index].modifiers.store(kDefaultHotkeys[index].modifiers, std::memory_order_relaxed);
-    }
+  for (std::size_t index = 0; index < mHotkeys.size(); ++index) {
+    mHotkeys[index].key.store(kDefaultHotkeys[index].key,
+                              std::memory_order_relaxed);
+    mHotkeys[index].modifiers.store(kDefaultHotkeys[index].modifiers,
+                                    std::memory_order_relaxed);
+  }
 }
 
-StructureUiState& StructureUiState::getInstance() {
-    static StructureUiState instance;
-    return instance;
+StructureUiState &StructureUiState::getInstance() {
+  static StructureUiState instance;
+  return instance;
 }
 
-StructureUiState::HotkeyStorage* StructureUiState::hotkeyStorage(std::size_t index) {
-    return index < mHotkeys.size() ? &mHotkeys[index] : nullptr;
+StructureUiState::HotkeyStorage *
+StructureUiState::hotkeyStorage(std::size_t index) {
+  return index < mHotkeys.size() ? &mHotkeys[index] : nullptr;
 }
 
-StructureUiState::HotkeyStorage const* StructureUiState::hotkeyStorage(std::size_t index) const {
-    return index < mHotkeys.size() ? &mHotkeys[index] : nullptr;
+StructureUiState::HotkeyStorage const *
+StructureUiState::hotkeyStorage(std::size_t index) const {
+  return index < mHotkeys.size() ? &mHotkeys[index] : nullptr;
 }
 
 bool StructureUiState::guiVisible() const {
-    return mGuiVisible.load(std::memory_order_acquire);
+  return mGuiVisible.load(std::memory_order_acquire);
 }
 
 bool StructureUiState::toggleGuiVisible() {
-    auto const opening = !mGuiVisible.load(std::memory_order_acquire);
-    mGuiVisible.store(opening, std::memory_order_release);
-    return opening;
+  auto const opening = !mGuiVisible.load(std::memory_order_acquire);
+  mGuiVisible.store(opening, std::memory_order_release);
+  return opening;
 }
 
 void StructureUiState::setGuiVisible(bool visible) {
-    mGuiVisible.store(visible, std::memory_order_release);
+  mGuiVisible.store(visible, std::memory_order_release);
 }
 
 bool StructureUiState::openingInputBlocked() const {
-    return mOpeningInputBlockFrames.load(std::memory_order_acquire) > 0;
+  return mOpeningInputBlockFrames.load(std::memory_order_acquire) > 0;
 }
 
 void StructureUiState::setOpeningInputBlockFrames(int frames) {
-    mOpeningInputBlockFrames.store(frames, std::memory_order_release);
+  mOpeningInputBlockFrames.store(frames, std::memory_order_release);
 }
 
 void StructureUiState::consumeOpeningInputBlockFrame() {
-    if (mOpeningInputBlockFrames.load(std::memory_order_acquire) > 0) {
-        mOpeningInputBlockFrames.fetch_sub(1, std::memory_order_acq_rel);
-    }
+  if (mOpeningInputBlockFrames.load(std::memory_order_acquire) > 0) {
+    mOpeningInputBlockFrames.fetch_sub(1, std::memory_order_acq_rel);
+  }
 }
 
 std::uint64_t StructureUiState::blockGameInputUntil() const {
-    return mBlockGameInputUntil.load(std::memory_order_acquire);
+  return mBlockGameInputUntil.load(std::memory_order_acquire);
 }
 
 void StructureUiState::setBlockGameInputUntil(std::uint64_t deadline) {
-    mBlockGameInputUntil.store(deadline, std::memory_order_release);
+  mBlockGameInputUntil.store(deadline, std::memory_order_release);
 }
 
 HudStateSnapshot StructureUiState::hud() const {
-    return {
-        mHudEnabled.load(std::memory_order_relaxed),
-        mHudShowFileName.load(std::memory_order_relaxed),
-        mHudShowLayer.load(std::memory_order_relaxed),
-        mHudShowOverallProgress.load(std::memory_order_relaxed),
-        mHudShowProgress.load(std::memory_order_relaxed),
-        mHudShowWrongState.load(std::memory_order_relaxed),
-        mHudShowWrongType.load(std::memory_order_relaxed),
-        mHudShowExtraBlocks.load(std::memory_order_relaxed),
-        mHudShowProjectedBlockName.load(std::memory_order_relaxed),
-        mHudPosition.load(std::memory_order_relaxed),
-        mUiScale.load(std::memory_order_relaxed)
-    };
+  return {mHudEnabled.load(std::memory_order_relaxed),
+          mHudShowFileName.load(std::memory_order_relaxed),
+          mHudShowLayer.load(std::memory_order_relaxed),
+          mHudShowOverallProgress.load(std::memory_order_relaxed),
+          mHudShowProgress.load(std::memory_order_relaxed),
+          mHudShowWrongState.load(std::memory_order_relaxed),
+          mHudShowWrongType.load(std::memory_order_relaxed),
+          mHudShowExtraBlocks.load(std::memory_order_relaxed),
+          mHudShowProjectedBlockName.load(std::memory_order_relaxed),
+          mHudPosition.load(std::memory_order_relaxed),
+          mUiScale.load(std::memory_order_relaxed)};
 }
 
 bool StructureUiState::setUiScale(float scale) {
-    return updateRelaxed(mUiScale, scale);
+  return updateRelaxed(mUiScale, scale);
 }
 
-bool StructureUiState::applyHud(HudStateSnapshot const& snapshot) {
-    bool changed = false;
-    changed = updateRelaxed(mHudEnabled, snapshot.enabled) || changed;
-    changed = updateRelaxed(mHudShowFileName, snapshot.showFileName) || changed;
-    changed = updateRelaxed(mHudShowLayer, snapshot.showLayer) || changed;
-    changed = updateRelaxed(mHudShowOverallProgress, snapshot.showOverallProgress) || changed;
-    changed = updateRelaxed(mHudShowProgress, snapshot.showProgress) || changed;
-    changed = updateRelaxed(mHudShowWrongState, snapshot.showWrongState) || changed;
-    changed = updateRelaxed(mHudShowWrongType, snapshot.showWrongType) || changed;
-    changed = updateRelaxed(mHudShowExtraBlocks, snapshot.showExtraBlocks) || changed;
-    changed = updateRelaxed(
-        mHudShowProjectedBlockName, snapshot.showProjectedBlockName
-    ) || changed;
-    changed = updateRelaxed(mHudPosition, snapshot.position) || changed;
-    changed = updateRelaxed(mUiScale, snapshot.uiScale) || changed;
-    return changed;
+bool StructureUiState::applyHud(HudStateSnapshot const &snapshot) {
+  bool changed = false;
+  changed = updateRelaxed(mHudEnabled, snapshot.enabled) || changed;
+  changed = updateRelaxed(mHudShowFileName, snapshot.showFileName) || changed;
+  changed = updateRelaxed(mHudShowLayer, snapshot.showLayer) || changed;
+  changed =
+      updateRelaxed(mHudShowOverallProgress, snapshot.showOverallProgress) ||
+      changed;
+  changed = updateRelaxed(mHudShowProgress, snapshot.showProgress) || changed;
+  changed =
+      updateRelaxed(mHudShowWrongState, snapshot.showWrongState) || changed;
+  changed = updateRelaxed(mHudShowWrongType, snapshot.showWrongType) || changed;
+  changed =
+      updateRelaxed(mHudShowExtraBlocks, snapshot.showExtraBlocks) || changed;
+  changed = updateRelaxed(mHudShowProjectedBlockName,
+                          snapshot.showProjectedBlockName) ||
+            changed;
+  changed = updateRelaxed(mHudPosition, snapshot.position) || changed;
+  changed = updateRelaxed(mUiScale, snapshot.uiScale) || changed;
+  return changed;
 }
 
 HotkeyBindingSnapshot StructureUiState::hotkey(std::size_t index) const {
-    auto const* storage = hotkeyStorage(index);
-    if (!storage) return {};
-    return {
-        storage->key.load(std::memory_order_relaxed),
-        storage->modifiers.load(std::memory_order_relaxed),
-        storage->capturing.load(std::memory_order_acquire)
-    };
+  auto const *storage = hotkeyStorage(index);
+  if (!storage)
+    return {};
+  return {storage->key.load(std::memory_order_relaxed),
+          storage->modifiers.load(std::memory_order_relaxed),
+          storage->capturing.load(std::memory_order_acquire)};
 }
 
 HotkeyBindingSnapshot StructureUiState::inputHotkey(std::size_t index) const {
-    auto const* storage = hotkeyStorage(index);
-    if (!storage) return {};
-    return {
-        storage->key.load(std::memory_order_acquire),
-        storage->modifiers.load(std::memory_order_acquire),
-        storage->capturing.load(std::memory_order_acquire)
-    };
+  auto const *storage = hotkeyStorage(index);
+  if (!storage)
+    return {};
+  return {storage->key.load(std::memory_order_acquire),
+          storage->modifiers.load(std::memory_order_acquire),
+          storage->capturing.load(std::memory_order_acquire)};
 }
 
-void StructureUiState::setHotkey(
-    std::size_t  index,
-    unsigned int key,
-    unsigned int modifiers
-) {
-    if (auto* storage = hotkeyStorage(index)) {
-        storage->key.store(key, std::memory_order_relaxed);
-        storage->modifiers.store(modifiers, std::memory_order_relaxed);
-    }
+void StructureUiState::setHotkey(std::size_t index, unsigned int key,
+                                 unsigned int modifiers) {
+  if (auto *storage = hotkeyStorage(index)) {
+    storage->key.store(key, std::memory_order_relaxed);
+    storage->modifiers.store(modifiers, std::memory_order_relaxed);
+  }
 }
 
 std::optional<std::size_t> StructureUiState::capturingHotkey() const {
-    // Only one hotkey can be capturing at a time (beginHotkeyCapture clears the
-    // rest), so a plain scan over every slot is sufficient and count-agnostic.
-    for (std::size_t index = 0; index < mHotkeys.size(); ++index) {
-        if (mHotkeys[index].capturing.load(std::memory_order_acquire)) return index;
-    }
-    return std::nullopt;
+  // Only one hotkey can be capturing at a time (beginHotkeyCapture clears the
+  // rest), so a plain scan over every slot is sufficient and count-agnostic.
+  for (std::size_t index = 0; index < mHotkeys.size(); ++index) {
+    if (mHotkeys[index].capturing.load(std::memory_order_acquire))
+      return index;
+  }
+  return std::nullopt;
 }
 
 void StructureUiState::beginHotkeyCapture(std::size_t index) {
-    stopHotkeyCapture();
-    if (auto* storage = hotkeyStorage(index)) {
-        storage->capturing.store(true, std::memory_order_release);
-    }
+  stopHotkeyCapture();
+  if (auto *storage = hotkeyStorage(index)) {
+    storage->capturing.store(true, std::memory_order_release);
+  }
 }
 
 void StructureUiState::stopHotkeyCapture() {
-    for (auto& hotkey : mHotkeys) hotkey.capturing.store(false, std::memory_order_release);
+  for (auto &hotkey : mHotkeys)
+    hotkey.capturing.store(false, std::memory_order_release);
 }
 
 void StructureUiState::clearHotkey(std::size_t index) {
-    if (auto* storage = hotkeyStorage(index)) {
-        storage->key.store(0, std::memory_order_release);
-        storage->modifiers.store(0, std::memory_order_release);
-        storage->capturing.store(false, std::memory_order_release);
-    }
+  if (auto *storage = hotkeyStorage(index)) {
+    storage->key.store(0, std::memory_order_release);
+    storage->modifiers.store(0, std::memory_order_release);
+    storage->capturing.store(false, std::memory_order_release);
+  }
 }
 
-void StructureUiState::bindCapturedHotkey(
-    std::size_t  index,
-    unsigned int key,
-    unsigned int modifiers
-) {
-    auto* target = hotkeyStorage(index);
-    if (!target) return;
-    for (std::size_t current = 0; current < mHotkeys.size(); ++current) {
-        if (current == index) continue;
-        auto& candidate = mHotkeys[current];
-        if (candidate.key.load(std::memory_order_relaxed) == key
-            && candidate.modifiers.load(std::memory_order_relaxed) == modifiers) {
-            candidate.key.store(0, std::memory_order_relaxed);
-            candidate.modifiers.store(0, std::memory_order_relaxed);
-        }
+void StructureUiState::bindCapturedHotkey(std::size_t index, unsigned int key,
+                                          unsigned int modifiers) {
+  auto *target = hotkeyStorage(index);
+  if (!target)
+    return;
+  for (std::size_t current = 0; current < mHotkeys.size(); ++current) {
+    if (current == index)
+      continue;
+    auto &candidate = mHotkeys[current];
+    if (candidate.key.load(std::memory_order_relaxed) == key &&
+        candidate.modifiers.load(std::memory_order_relaxed) == modifiers) {
+      candidate.key.store(0, std::memory_order_relaxed);
+      candidate.modifiers.store(0, std::memory_order_relaxed);
     }
-    target->key.store(key, std::memory_order_release);
-    target->modifiers.store(modifiers, std::memory_order_release);
-    stopHotkeyCapture();
+  }
+  target->key.store(key, std::memory_order_release);
+  target->modifiers.store(modifiers, std::memory_order_release);
+  stopHotkeyCapture();
 }
 
 void StructureUiState::resetHotkeys() {
-    for (std::size_t index = 0; index < mHotkeys.size(); ++index) {
-        mHotkeys[index].key.store(kDefaultHotkeys[index].key, std::memory_order_relaxed);
-        mHotkeys[index].modifiers.store(kDefaultHotkeys[index].modifiers, std::memory_order_relaxed);
-    }
-    stopHotkeyCapture();
+  for (std::size_t index = 0; index < mHotkeys.size(); ++index) {
+    mHotkeys[index].key.store(kDefaultHotkeys[index].key,
+                              std::memory_order_relaxed);
+    mHotkeys[index].modifiers.store(kDefaultHotkeys[index].modifiers,
+                                    std::memory_order_relaxed);
+  }
+  stopHotkeyCapture();
 }
 
 void StructureUiState::setControlHeld(bool held) {
-    mControlHeld.store(held, std::memory_order_release);
+  mControlHeld.store(held, std::memory_order_release);
 }
-void StructureUiState::setAltHeld(bool held) { mAltHeld.store(held, std::memory_order_release); }
-void StructureUiState::setShiftHeld(bool held) { mShiftHeld.store(held, std::memory_order_release); }
+void StructureUiState::setAltHeld(bool held) {
+  mAltHeld.store(held, std::memory_order_release);
+}
+void StructureUiState::setShiftHeld(bool held) {
+  mShiftHeld.store(held, std::memory_order_release);
+}
 
 unsigned int StructureUiState::currentHotkeyModifiers() const {
-    unsigned int modifiers{};
-    if (mControlHeld.load(std::memory_order_acquire)) modifiers |= lholo::ui::kHotkeyModifierControl;
-    if (mAltHeld.load(std::memory_order_acquire)) modifiers |= lholo::ui::kHotkeyModifierAlt;
-    if (mShiftHeld.load(std::memory_order_acquire)) modifiers |= lholo::ui::kHotkeyModifierShift;
-    return modifiers;
+  unsigned int modifiers{};
+  if (mControlHeld.load(std::memory_order_acquire))
+    modifiers |= lholo::ui::kHotkeyModifierControl;
+  if (mAltHeld.load(std::memory_order_acquire))
+    modifiers |= lholo::ui::kHotkeyModifierAlt;
+  if (mShiftHeld.load(std::memory_order_acquire))
+    modifiers |= lholo::ui::kHotkeyModifierShift;
+  return modifiers;
 }
 
 bool StructureUiState::tryPressHotkey(std::size_t index) {
-    auto* storage = hotkeyStorage(index);
-    return storage && !storage->held.exchange(true, std::memory_order_acq_rel);
+  auto *storage = hotkeyStorage(index);
+  return storage && !storage->held.exchange(true, std::memory_order_acq_rel);
 }
 
-bool StructureUiState::releaseHotkeysForKey(unsigned int key, std::uint64_t now) {
-    bool consumed{};
-    for (auto& hotkey : mHotkeys) {
-        if (key == hotkey.key.load(std::memory_order_acquire)) {
-            consumed = hotkey.held.exchange(false, std::memory_order_acq_rel) || consumed;
-        }
+bool StructureUiState::releaseHotkeysForKey(unsigned int key,
+                                            std::uint64_t now) {
+  bool consumed{};
+  for (auto &hotkey : mHotkeys) {
+    if (key == hotkey.key.load(std::memory_order_acquire)) {
+      consumed =
+          hotkey.held.exchange(false, std::memory_order_acq_rel) || consumed;
     }
-    if (key < mConsumeKeyReleaseUntil.size()) {
-        auto& deadline = mConsumeKeyReleaseUntil[key];
-        if (consumed) {
-            deadline.store(now + 100, std::memory_order_release);
-            return true;
-        }
-        if (now <= deadline.load(std::memory_order_acquire)) return true;
+  }
+  if (key < mConsumeKeyReleaseUntil.size()) {
+    auto &deadline = mConsumeKeyReleaseUntil[key];
+    if (consumed) {
+      deadline.store(now + 100, std::memory_order_release);
+      return true;
     }
-    return false;
+    if (now <= deadline.load(std::memory_order_acquire))
+      return true;
+  }
+  return false;
 }
 
 void StructureUiState::resetHotkeyState() {
-    mControlHeld.store(false, std::memory_order_release);
-    mAltHeld.store(false, std::memory_order_release);
-    mShiftHeld.store(false, std::memory_order_release);
-    for (auto& hotkey : mHotkeys) hotkey.held.store(false, std::memory_order_release);
-    for (auto& deadline : mConsumeKeyReleaseUntil) deadline.store(0, std::memory_order_release);
+  mControlHeld.store(false, std::memory_order_release);
+  mAltHeld.store(false, std::memory_order_release);
+  mShiftHeld.store(false, std::memory_order_release);
+  for (auto &hotkey : mHotkeys)
+    hotkey.held.store(false, std::memory_order_release);
+  for (auto &deadline : mConsumeKeyReleaseUntil)
+    deadline.store(0, std::memory_order_release);
 }
 
 std::uint64_t StructureUiState::ignoreHotkeyUntil() const {
-    return mIgnoreHotkeyUntil.load(std::memory_order_acquire);
+  return mIgnoreHotkeyUntil.load(std::memory_order_acquire);
 }
 
 void StructureUiState::setIgnoreHotkeyUntil(std::uint64_t deadline) {
-    mIgnoreHotkeyUntil.store(deadline, std::memory_order_release);
+  mIgnoreHotkeyUntil.store(deadline, std::memory_order_release);
 }
 
 void StructureUiState::queueMove(std::size_t index) {
-    switch (index) {
-    case 0: mPendingOffsetX.fetch_sub(1, std::memory_order_relaxed); break;
-    case 1: mPendingOffsetX.fetch_add(1, std::memory_order_relaxed); break;
-    case 2: mPendingOffsetZ.fetch_sub(1, std::memory_order_relaxed); break;
-    case 3: mPendingOffsetZ.fetch_add(1, std::memory_order_relaxed); break;
-    case 4: mPendingOffsetY.fetch_add(1, std::memory_order_relaxed); break;
-    case 5: mPendingOffsetY.fetch_sub(1, std::memory_order_relaxed); break;
-    default: break;
-    }
+  switch (index) {
+  case 0:
+    mPendingOffsetX.fetch_sub(1, std::memory_order_relaxed);
+    break;
+  case 1:
+    mPendingOffsetX.fetch_add(1, std::memory_order_relaxed);
+    break;
+  case 2:
+    mPendingOffsetZ.fetch_sub(1, std::memory_order_relaxed);
+    break;
+  case 3:
+    mPendingOffsetZ.fetch_add(1, std::memory_order_relaxed);
+    break;
+  case 4:
+    mPendingOffsetY.fetch_add(1, std::memory_order_relaxed);
+    break;
+  case 5:
+    mPendingOffsetY.fetch_sub(1, std::memory_order_relaxed);
+    break;
+  default:
+    break;
+  }
+}
+
+void StructureUiState::queueOffsetDelta(int deltaX, int deltaY, int deltaZ) {
+  if (deltaX != 0)
+    mPendingOffsetX.fetch_add(deltaX, std::memory_order_relaxed);
+  if (deltaY != 0)
+    mPendingOffsetY.fetch_add(deltaY, std::memory_order_relaxed);
+  if (deltaZ != 0)
+    mPendingOffsetZ.fetch_add(deltaZ, std::memory_order_relaxed);
+}
+
+void StructureUiState::addOffsetPreview(int deltaX, int deltaY, int deltaZ) {
+  if (deltaX != 0)
+    mPreviewOffsetX.fetch_add(deltaX, std::memory_order_relaxed);
+  if (deltaY != 0)
+    mPreviewOffsetY.fetch_add(deltaY, std::memory_order_relaxed);
+  if (deltaZ != 0)
+    mPreviewOffsetZ.fetch_add(deltaZ, std::memory_order_relaxed);
+  mPreviewApplyDeadline.store(GetTickCount64() + 1000,
+                              std::memory_order_release);
+}
+
+std::array<int, 3> StructureUiState::offsetPreview() const {
+  return {mPreviewOffsetX.load(std::memory_order_acquire),
+          mPreviewOffsetY.load(std::memory_order_acquire),
+          mPreviewOffsetZ.load(std::memory_order_acquire)};
+}
+
+bool StructureUiState::offsetPreviewActive() const {
+  return mPreviewOffsetX.load(std::memory_order_acquire) != 0 ||
+         mPreviewOffsetY.load(std::memory_order_acquire) != 0 ||
+         mPreviewOffsetZ.load(std::memory_order_acquire) != 0;
+}
+
+std::uint64_t StructureUiState::offsetPreviewDeadline() const {
+  return mPreviewApplyDeadline.load(std::memory_order_acquire);
+}
+
+void StructureUiState::setOffsetPreviewDeadline(std::uint64_t deadline) {
+  mPreviewApplyDeadline.store(deadline, std::memory_order_release);
+}
+
+std::array<int, 3> StructureUiState::consumeOffsetPreview() {
+  auto const preview = offsetPreview();
+  clearOffsetPreview();
+  return preview;
+}
+
+void StructureUiState::clearOffsetPreview() {
+  mPreviewOffsetX.store(0, std::memory_order_release);
+  mPreviewOffsetY.store(0, std::memory_order_release);
+  mPreviewOffsetZ.store(0, std::memory_order_release);
+  mPreviewApplyDeadline.store(0, std::memory_order_release);
 }
 
 void StructureUiState::queueLayerDelta(int delta) {
-    if (delta > 0) mPendingLayerDelta.fetch_add(1, std::memory_order_relaxed);
-    else if (delta < 0) mPendingLayerDelta.fetch_sub(1, std::memory_order_relaxed);
+  if (delta > 0)
+    mPendingLayerDelta.fetch_add(1, std::memory_order_relaxed);
+  else if (delta < 0)
+    mPendingLayerDelta.fetch_sub(1, std::memory_order_relaxed);
 }
 
 void StructureUiState::queueLoadProjection() {
-    mPendingLoadProjection.store(true, std::memory_order_release);
+  mPendingLoadProjection.store(true, std::memory_order_release);
 }
 
 void StructureUiState::queueCloseProjection() {
-    mPendingCloseProjection.store(true, std::memory_order_release);
+  mPendingCloseProjection.store(true, std::memory_order_release);
 }
 
 void StructureUiState::requestSettingsSave() {
-    mPendingSettingsSave.store(true, std::memory_order_release);
+  mPendingSettingsSave.store(true, std::memory_order_release);
 }
 
 PendingHotkeyActions StructureUiState::consumePendingHotkeyActions() {
-    return {
-        mPendingOffsetX.exchange(0, std::memory_order_acq_rel),
-        mPendingOffsetY.exchange(0, std::memory_order_acq_rel),
-        mPendingOffsetZ.exchange(0, std::memory_order_acq_rel),
-        mPendingLayerDelta.exchange(0, std::memory_order_acq_rel),
-        mPendingSettingsSave.exchange(false, std::memory_order_acq_rel),
-        mPendingLoadProjection.exchange(false, std::memory_order_acq_rel),
-        mPendingCloseProjection.exchange(false, std::memory_order_acq_rel)
-    };
+  return {mPendingOffsetX.exchange(0, std::memory_order_acq_rel),
+          mPendingOffsetY.exchange(0, std::memory_order_acq_rel),
+          mPendingOffsetZ.exchange(0, std::memory_order_acq_rel),
+          mPendingLayerDelta.exchange(0, std::memory_order_acq_rel),
+          mPendingSettingsSave.exchange(false, std::memory_order_acq_rel),
+          mPendingLoadProjection.exchange(false, std::memory_order_acq_rel),
+          mPendingCloseProjection.exchange(false, std::memory_order_acq_rel)};
 }
 
 bool StructureUiState::experimentalConsentGiven() const {
-    return mExperimentalConsent.load(std::memory_order_acquire);
+  return mExperimentalConsent.load(std::memory_order_acquire);
 }
 
 void StructureUiState::setExperimentalConsentGiven(bool given) {
-    mExperimentalConsent.store(given, std::memory_order_release);
+  mExperimentalConsent.store(given, std::memory_order_release);
 }
 
 bool StructureUiState::materialHudEnabled() const {
-    return mMaterialHudEnabled.load(std::memory_order_acquire);
+  return mMaterialHudEnabled.load(std::memory_order_acquire);
 }
 
 void StructureUiState::setMaterialHudEnabled(bool enabled) {
-    mMaterialHudEnabled.store(enabled, std::memory_order_release);
+  mMaterialHudEnabled.store(enabled, std::memory_order_release);
 }
 
 int StructureUiState::materialHudPosition() const {
-    return mMaterialHudPosition.load(std::memory_order_acquire);
+  return mMaterialHudPosition.load(std::memory_order_acquire);
 }
 
 void StructureUiState::setMaterialHudPosition(int position) {
-    mMaterialHudPosition.store(std::clamp(position, 0, 3), std::memory_order_release);
+  mMaterialHudPosition.store(std::clamp(position, 0, 3),
+                             std::memory_order_release);
 }
 
 void StructureUiState::setActionHint(std::string text, std::uint64_t expiry) {
-    {
-        std::lock_guard lock(mActionHintMutex);
-        mActionHintText = std::move(text);
-    }
-    mActionHintExpiry.store(expiry, std::memory_order_release);
+  {
+    std::lock_guard lock(mActionHintMutex);
+    mActionHintText = std::move(text);
+  }
+  mActionHintExpiry.store(expiry, std::memory_order_release);
 }
 
 std::uint64_t StructureUiState::actionHintExpiry() const {
-    return mActionHintExpiry.load(std::memory_order_acquire);
+  return mActionHintExpiry.load(std::memory_order_acquire);
 }
 
 ActionHintSnapshot StructureUiState::actionHint() const {
-    auto const expiry = mActionHintExpiry.load(std::memory_order_acquire);
-    std::lock_guard lock(mActionHintMutex);
-    return {mActionHintText, expiry};
+  auto const expiry = mActionHintExpiry.load(std::memory_order_acquire);
+  std::lock_guard lock(mActionHintMutex);
+  return {mActionHintText, expiry};
 }
 
 void StructureUiState::requestMaterialList() {
-    // A loaded structure has an immutable material bill. Reopening the popup
-    // must reuse that snapshot instead of rescanning a potentially huge file.
-    if (mMaterialListReady.load(std::memory_order_acquire)) return;
-    mMaterialListRequested.store(true, std::memory_order_release);
+  // A loaded structure has an immutable material bill. Reopening the popup
+  // must reuse that snapshot instead of rescanning a potentially huge file.
+  if (mMaterialListReady.load(std::memory_order_acquire))
+    return;
+  mMaterialListRequested.store(true, std::memory_order_release);
 }
 
 bool StructureUiState::consumeMaterialListRequest() {
-    return mMaterialListRequested.exchange(false, std::memory_order_acq_rel);
+  return mMaterialListRequested.exchange(false, std::memory_order_acq_rel);
 }
 
 bool StructureUiState::materialListReady() const {
-    return mMaterialListReady.load(std::memory_order_acquire);
+  return mMaterialListReady.load(std::memory_order_acquire);
 }
 
-void StructureUiState::replaceMaterialRequirements(std::vector<MaterialRequirement> materials) {
-    {
-        std::lock_guard lock(mMaterialMutex);
-        mMaterialRequirements = std::move(materials);
-    }
-    // Publish readiness only after the complete snapshot is visible. An empty
-    // list is also a valid cached result and must not trigger endless rescans.
-    mMaterialListReady.store(true, std::memory_order_release);
-}
-
-std::vector<MaterialRequirement> StructureUiState::materialRequirements() const {
+void StructureUiState::replaceMaterialRequirements(
+    std::vector<MaterialRequirement> materials) {
+  {
     std::lock_guard lock(mMaterialMutex);
-    return mMaterialRequirements;
+    mMaterialRequirements = std::move(materials);
+  }
+  // Publish readiness only after the complete snapshot is visible. An empty
+  // list is also a valid cached result and must not trigger endless rescans.
+  mMaterialListReady.store(true, std::memory_order_release);
+}
+
+std::vector<MaterialRequirement>
+StructureUiState::materialRequirements() const {
+  std::lock_guard lock(mMaterialMutex);
+  return mMaterialRequirements;
 }
 
 void StructureUiState::replaceMaterialHudSnapshot(
-    std::vector<MaterialRequirement> materials,
-    std::vector<int>                 available
-) {
-    std::lock_guard lock(mMaterialMutex);
-    mMaterialHudRequirements = std::move(materials);
-    mMaterialHudAvailability = std::move(available);
-    mMaterialHudReady = true;
+    std::vector<MaterialRequirement> materials, std::vector<int> available) {
+  std::lock_guard lock(mMaterialMutex);
+  mMaterialHudRequirements = std::move(materials);
+  mMaterialHudAvailability = std::move(available);
+  mMaterialHudReady = true;
 }
 
 void StructureUiState::setMaterialHudAvailability(std::vector<int> counts) {
-    std::lock_guard lock(mMaterialMutex);
-    mMaterialHudAvailability = std::move(counts);
+  std::lock_guard lock(mMaterialMutex);
+  mMaterialHudAvailability = std::move(counts);
 }
 
 MaterialHudSnapshot StructureUiState::materialHudSnapshot() const {
-    std::lock_guard lock(mMaterialMutex);
-    return {mMaterialHudRequirements, mMaterialHudAvailability, mMaterialHudReady};
+  std::lock_guard lock(mMaterialMutex);
+  return {mMaterialHudRequirements, mMaterialHudAvailability,
+          mMaterialHudReady};
 }
 
 void StructureUiState::clearMaterialHud() {
-    std::lock_guard lock(mMaterialMutex);
-    mMaterialHudRequirements.clear();
-    mMaterialHudAvailability.clear();
-    mMaterialHudReady = false;
+  std::lock_guard lock(mMaterialMutex);
+  mMaterialHudRequirements.clear();
+  mMaterialHudAvailability.clear();
+  mMaterialHudReady = false;
 }
 
 void StructureUiState::clearMaterials() {
-    mMaterialListRequested.store(false, std::memory_order_release);
-    mMaterialListReady.store(false, std::memory_order_release);
-    std::lock_guard lock(mMaterialMutex);
-    mMaterialRequirements.clear();
-    mMaterialHudRequirements.clear();
-    mMaterialHudAvailability.clear();
-    mMaterialHudReady = false;
+  mMaterialListRequested.store(false, std::memory_order_release);
+  mMaterialListReady.store(false, std::memory_order_release);
+  std::lock_guard lock(mMaterialMutex);
+  mMaterialRequirements.clear();
+  mMaterialHudRequirements.clear();
+  mMaterialHudAvailability.clear();
+  mMaterialHudReady = false;
 }
 
 void StructureUiState::resetWorldSession() {
-    mGuiVisible.store(false, std::memory_order_release);
-    mOpeningInputBlockFrames.store(0, std::memory_order_release);
-    mBlockGameInputUntil.store(0, std::memory_order_release);
-    mPendingOffsetX.store(0, std::memory_order_release);
-    mPendingOffsetY.store(0, std::memory_order_release);
-    mPendingOffsetZ.store(0, std::memory_order_release);
-    mPendingLayerDelta.store(0, std::memory_order_release);
-    mPendingLoadProjection.store(false, std::memory_order_release);
-    mPendingCloseProjection.store(false, std::memory_order_release);
-    mIgnoreHotkeyUntil.store(0, std::memory_order_release);
-    stopHotkeyCapture();
-    resetHotkeyState();
-    setActionHint({}, 0);
-    clearMaterials();
+  mGuiVisible.store(false, std::memory_order_release);
+  mOpeningInputBlockFrames.store(0, std::memory_order_release);
+  mBlockGameInputUntil.store(0, std::memory_order_release);
+  mPendingOffsetX.store(0, std::memory_order_release);
+  mPendingOffsetY.store(0, std::memory_order_release);
+  mPendingOffsetZ.store(0, std::memory_order_release);
+  clearOffsetPreview();
+  mPendingLayerDelta.store(0, std::memory_order_release);
+  mPendingLoadProjection.store(false, std::memory_order_release);
+  mPendingCloseProjection.store(false, std::memory_order_release);
+  mIgnoreHotkeyUntil.store(0, std::memory_order_release);
+  stopHotkeyCapture();
+  resetHotkeyState();
+  setActionHint({}, 0);
+  clearMaterials();
 }
 
 } // namespace lholo::structure::detail

--- a/src/structure/StructureUiState.h
+++ b/src/structure/StructureUiState.h
@@ -20,203 +20,213 @@
 namespace lholo::structure::detail {
 
 struct MaterialRequirement {
-    std::string   displayName;
-    std::string   typeName;
-    // Resolved inventory item type. Empty for materials without a directly
-    // countable inventory form (for example projected water/lava cells).
-    std::string   itemId;
-    std::uint64_t count{};
-    // Max stack size of the item this block resolves to (64 normally, 16 for
-    // signs etc., 1 for filled buckets). Used for the JE-style "N (a x S + b)"
-    // count display. Computed on the tick thread; 64 when unknown.
-    int           stackSize{64};
+  std::string displayName;
+  std::string typeName;
+  // Resolved inventory item type. Empty for materials without a directly
+  // countable inventory form (for example projected water/lava cells).
+  std::string itemId;
+  std::uint64_t count{};
+  // Max stack size of the item this block resolves to (64 normally, 16 for
+  // signs etc., 1 for filled buckets). Used for the JE-style "N (a x S + b)"
+  // count display. Computed on the tick thread; 64 when unknown.
+  int stackSize{64};
 };
 
 struct ActionHintSnapshot {
-    std::string   text;
-    std::uint64_t expiry{};
+  std::string text;
+  std::uint64_t expiry{};
 };
 
 // Current-layer missing requirements plus matching inventory counts, copied
 // together so the render thread never observes mismatched vectors.
 struct MaterialHudSnapshot {
-    std::vector<MaterialRequirement> requirements;
-    std::vector<int>                 available;
-    bool                             ready{};
+  std::vector<MaterialRequirement> requirements;
+  std::vector<int> available;
+  bool ready{};
 };
 
 struct HudStateSnapshot {
-    bool  enabled{true};
-    bool  showFileName{true};
-    bool  showLayer{true};
-    bool  showOverallProgress{};
-    bool  showProgress{true};
-    bool  showWrongState{true};
-    bool  showWrongType{true};
-    bool  showExtraBlocks{true};
-    bool  showProjectedBlockName{true};
-    int   position{1};
-    float uiScale{2.0f};
+  bool enabled{true};
+  bool showFileName{true};
+  bool showLayer{true};
+  bool showOverallProgress{};
+  bool showProgress{true};
+  bool showWrongState{true};
+  bool showWrongType{true};
+  bool showExtraBlocks{true};
+  bool showProjectedBlockName{true};
+  int position{1};
+  float uiScale{2.0f};
 };
 
 struct HotkeyBindingSnapshot {
-    unsigned int key{};
-    unsigned int modifiers{};
-    bool         capturing{};
+  unsigned int key{};
+  unsigned int modifiers{};
+  bool capturing{};
 };
 
 struct PendingHotkeyActions {
-    int  offsetX{};
-    int  offsetY{};
-    int  offsetZ{};
-    int  layerDelta{};
-    bool settingsSave{};
-    bool loadProjection{};
-    bool closeProjection{};
+  int offsetX{};
+  int offsetY{};
+  int offsetZ{};
+  int layerDelta{};
+  bool settingsSave{};
+  bool loadProjection{};
+  bool closeProjection{};
 };
 
 class StructureUiState {
 public:
-    static StructureUiState& getInstance();
+  static StructureUiState &getInstance();
 
-    StructureUiState(StructureUiState const&)            = delete;
-    StructureUiState(StructureUiState&&)                 = delete;
-    StructureUiState& operator=(StructureUiState const&) = delete;
-    StructureUiState& operator=(StructureUiState&&)      = delete;
+  StructureUiState(StructureUiState const &) = delete;
+  StructureUiState(StructureUiState &&) = delete;
+  StructureUiState &operator=(StructureUiState const &) = delete;
+  StructureUiState &operator=(StructureUiState &&) = delete;
 
-    [[nodiscard]] bool guiVisible() const;
-    [[nodiscard]] bool toggleGuiVisible();
-    void setGuiVisible(bool visible);
-    [[nodiscard]] bool openingInputBlocked() const;
-    void setOpeningInputBlockFrames(int frames);
-    void consumeOpeningInputBlockFrame();
-    [[nodiscard]] std::uint64_t blockGameInputUntil() const;
-    void setBlockGameInputUntil(std::uint64_t deadline);
+  [[nodiscard]] bool guiVisible() const;
+  [[nodiscard]] bool toggleGuiVisible();
+  void setGuiVisible(bool visible);
+  [[nodiscard]] bool openingInputBlocked() const;
+  void setOpeningInputBlockFrames(int frames);
+  void consumeOpeningInputBlockFrame();
+  [[nodiscard]] std::uint64_t blockGameInputUntil() const;
+  void setBlockGameInputUntil(std::uint64_t deadline);
 
-    [[nodiscard]] HudStateSnapshot hud() const;
-    bool setUiScale(float scale);
-    bool applyHud(HudStateSnapshot const& snapshot);
+  [[nodiscard]] HudStateSnapshot hud() const;
+  bool setUiScale(float scale);
+  bool applyHud(HudStateSnapshot const &snapshot);
 
-    [[nodiscard]] HotkeyBindingSnapshot hotkey(std::size_t index) const;
-    [[nodiscard]] HotkeyBindingSnapshot inputHotkey(std::size_t index) const;
-    void setHotkey(std::size_t index, unsigned int key, unsigned int modifiers);
-    [[nodiscard]] std::optional<std::size_t> capturingHotkey() const;
-    void beginHotkeyCapture(std::size_t index);
-    void stopHotkeyCapture();
-    void clearHotkey(std::size_t index);
-    void bindCapturedHotkey(
-        std::size_t  index,
-        unsigned int key,
-        unsigned int modifiers
-    );
-    void resetHotkeys();
+  [[nodiscard]] HotkeyBindingSnapshot hotkey(std::size_t index) const;
+  [[nodiscard]] HotkeyBindingSnapshot inputHotkey(std::size_t index) const;
+  void setHotkey(std::size_t index, unsigned int key, unsigned int modifiers);
+  [[nodiscard]] std::optional<std::size_t> capturingHotkey() const;
+  void beginHotkeyCapture(std::size_t index);
+  void stopHotkeyCapture();
+  void clearHotkey(std::size_t index);
+  void bindCapturedHotkey(std::size_t index, unsigned int key,
+                          unsigned int modifiers);
+  void resetHotkeys();
 
-    void setControlHeld(bool held);
-    void setAltHeld(bool held);
-    void setShiftHeld(bool held);
-    [[nodiscard]] unsigned int currentHotkeyModifiers() const;
-    [[nodiscard]] bool tryPressHotkey(std::size_t index);
-    [[nodiscard]] bool releaseHotkeysForKey(unsigned int key, std::uint64_t now);
-    void resetHotkeyState();
-    [[nodiscard]] std::uint64_t ignoreHotkeyUntil() const;
-    void setIgnoreHotkeyUntil(std::uint64_t deadline);
+  void setControlHeld(bool held);
+  void setAltHeld(bool held);
+  void setShiftHeld(bool held);
+  [[nodiscard]] unsigned int currentHotkeyModifiers() const;
+  [[nodiscard]] bool tryPressHotkey(std::size_t index);
+  [[nodiscard]] bool releaseHotkeysForKey(unsigned int key, std::uint64_t now);
+  void resetHotkeyState();
+  [[nodiscard]] std::uint64_t ignoreHotkeyUntil() const;
+  void setIgnoreHotkeyUntil(std::uint64_t deadline);
 
-    void queueMove(std::size_t index);
-    void queueLayerDelta(int delta);
-    void queueLoadProjection();
-    void queueCloseProjection();
-    void requestSettingsSave();
-    [[nodiscard]] PendingHotkeyActions consumePendingHotkeyActions();
+  void queueMove(std::size_t index);
+  void queueOffsetDelta(int deltaX, int deltaY, int deltaZ);
+  // Preview offset state: the user sees a temporary whole-structure outline
+  // while adjusting, and the real transform changes only after the preview
+  // expires with 1 second of inactivity.
+  void addOffsetPreview(int deltaX, int deltaY, int deltaZ);
+  [[nodiscard]] std::array<int, 3> offsetPreview() const;
+  [[nodiscard]] bool offsetPreviewActive() const;
+  [[nodiscard]] std::uint64_t offsetPreviewDeadline() const;
+  void setOffsetPreviewDeadline(std::uint64_t deadline);
+  [[nodiscard]] std::array<int, 3> consumeOffsetPreview();
+  void clearOffsetPreview();
+  void queueLayerDelta(int delta);
+  void queueLoadProjection();
+  void queueCloseProjection();
+  void requestSettingsSave();
+  [[nodiscard]] PendingHotkeyActions consumePendingHotkeyActions();
 
-    [[nodiscard]] bool experimentalConsentGiven() const;
-    void setExperimentalConsentGiven(bool given);
-    [[nodiscard]] bool materialHudEnabled() const;
-    void setMaterialHudEnabled(bool enabled);
-    [[nodiscard]] int materialHudPosition() const;
-    void setMaterialHudPosition(int position);
-    void setActionHint(std::string text, std::uint64_t expiry);
-    [[nodiscard]] std::uint64_t actionHintExpiry() const;
-    [[nodiscard]] ActionHintSnapshot actionHint() const;
+  [[nodiscard]] bool experimentalConsentGiven() const;
+  void setExperimentalConsentGiven(bool given);
+  [[nodiscard]] bool materialHudEnabled() const;
+  void setMaterialHudEnabled(bool enabled);
+  [[nodiscard]] int materialHudPosition() const;
+  void setMaterialHudPosition(int position);
+  void setActionHint(std::string text, std::uint64_t expiry);
+  [[nodiscard]] std::uint64_t actionHintExpiry() const;
+  [[nodiscard]] ActionHintSnapshot actionHint() const;
 
-    void requestMaterialList();
-    [[nodiscard]] bool consumeMaterialListRequest();
-    [[nodiscard]] bool materialListReady() const;
-    void replaceMaterialRequirements(std::vector<MaterialRequirement> materials);
-    [[nodiscard]] std::vector<MaterialRequirement> materialRequirements() const;
-    // The material-list popup and the current-layer HUD deliberately own
-    // separate snapshots: the popup covers the whole structure, while the HUD
-    // follows projection correction and layer visibility.
-    void replaceMaterialHudSnapshot(
-        std::vector<MaterialRequirement> materials,
-        std::vector<int>                 available
-    );
-    void setMaterialHudAvailability(std::vector<int> counts);
-    [[nodiscard]] MaterialHudSnapshot materialHudSnapshot() const;
-    void clearMaterialHud();
-    void clearMaterials();
+  void requestMaterialList();
+  [[nodiscard]] bool consumeMaterialListRequest();
+  [[nodiscard]] bool materialListReady() const;
+  void replaceMaterialRequirements(std::vector<MaterialRequirement> materials);
+  [[nodiscard]] std::vector<MaterialRequirement> materialRequirements() const;
+  // The material-list popup and the current-layer HUD deliberately own
+  // separate snapshots: the popup covers the whole structure, while the HUD
+  // follows projection correction and layer visibility.
+  void replaceMaterialHudSnapshot(std::vector<MaterialRequirement> materials,
+                                  std::vector<int> available);
+  void setMaterialHudAvailability(std::vector<int> counts);
+  [[nodiscard]] MaterialHudSnapshot materialHudSnapshot() const;
+  void clearMaterialHud();
+  void clearMaterials();
 
-    // Clears transient UI and queued actions owned by the current world. User
-    // preferences (HUD layout, hotkey bindings, consent) remain unchanged.
-    void resetWorldSession();
+  // Clears transient UI and queued actions owned by the current world. User
+  // preferences (HUD layout, hotkey bindings, consent) remain unchanged.
+  void resetWorldSession();
 
 private:
-    StructureUiState();
+  StructureUiState();
 
-    struct HotkeyStorage {
-        std::atomic_uint key{};
-        std::atomic_uint modifiers{};
-        std::atomic_bool capturing{};
-        std::atomic_bool held{};
-    };
+  struct HotkeyStorage {
+    std::atomic_uint key{};
+    std::atomic_uint modifiers{};
+    std::atomic_bool capturing{};
+    std::atomic_bool held{};
+  };
 
-    [[nodiscard]] HotkeyStorage* hotkeyStorage(std::size_t index);
-    [[nodiscard]] HotkeyStorage const* hotkeyStorage(std::size_t index) const;
+  [[nodiscard]] HotkeyStorage *hotkeyStorage(std::size_t index);
+  [[nodiscard]] HotkeyStorage const *hotkeyStorage(std::size_t index) const;
 
-    std::atomic_bool     mGuiVisible{false};
-    std::atomic_int      mOpeningInputBlockFrames{0};
-    std::atomic_uint64_t mBlockGameInputUntil{};
+  std::atomic_bool mGuiVisible{false};
+  std::atomic_int mOpeningInputBlockFrames{0};
+  std::atomic_uint64_t mBlockGameInputUntil{};
 
-    std::atomic_bool  mHudEnabled{true};
-    std::atomic_bool  mHudShowFileName{true};
-    std::atomic_bool  mHudShowLayer{true};
-    std::atomic_bool  mHudShowOverallProgress{false};
-    std::atomic_bool  mHudShowProgress{true};
-    std::atomic_bool  mHudShowWrongState{true};
-    std::atomic_bool  mHudShowWrongType{true};
-    std::atomic_bool  mHudShowExtraBlocks{true};
-    std::atomic_bool  mHudShowProjectedBlockName{true};
-    std::atomic_int   mHudPosition{1};
-    std::atomic<float> mUiScale{2.0f};
+  std::atomic_bool mHudEnabled{true};
+  std::atomic_bool mHudShowFileName{true};
+  std::atomic_bool mHudShowLayer{true};
+  std::atomic_bool mHudShowOverallProgress{false};
+  std::atomic_bool mHudShowProgress{true};
+  std::atomic_bool mHudShowWrongState{true};
+  std::atomic_bool mHudShowWrongType{true};
+  std::atomic_bool mHudShowExtraBlocks{true};
+  std::atomic_bool mHudShowProjectedBlockName{true};
+  std::atomic_int mHudPosition{1};
+  std::atomic<float> mUiScale{2.0f};
 
-    std::array<HotkeyStorage, input::kHotkeyCount> mHotkeys;
-    std::atomic_bool mControlHeld{false};
-    std::atomic_bool mAltHeld{false};
-    std::atomic_bool mShiftHeld{false};
-    std::array<std::atomic_uint64_t, 256> mConsumeKeyReleaseUntil{};
+  std::array<HotkeyStorage, input::kHotkeyCount> mHotkeys;
+  std::atomic_bool mControlHeld{false};
+  std::atomic_bool mAltHeld{false};
+  std::atomic_bool mShiftHeld{false};
+  std::array<std::atomic_uint64_t, 256> mConsumeKeyReleaseUntil{};
 
-    std::atomic_int      mPendingOffsetX{0};
-    std::atomic_int      mPendingOffsetY{0};
-    std::atomic_int      mPendingOffsetZ{0};
-    std::atomic_int      mPendingLayerDelta{0};
-    std::atomic_bool     mPendingLoadProjection{false};
-    std::atomic_bool     mPendingCloseProjection{false};
-    std::atomic_bool     mPendingSettingsSave{false};
-    std::atomic_uint64_t mIgnoreHotkeyUntil{0};
+  std::atomic_int mPendingOffsetX{0};
+  std::atomic_int mPendingOffsetY{0};
+  std::atomic_int mPendingOffsetZ{0};
+  std::atomic_int mPreviewOffsetX{0};
+  std::atomic_int mPreviewOffsetY{0};
+  std::atomic_int mPreviewOffsetZ{0};
+  std::atomic_uint64_t mPreviewApplyDeadline{0};
+  std::atomic_int mPendingLayerDelta{0};
+  std::atomic_bool mPendingLoadProjection{false};
+  std::atomic_bool mPendingCloseProjection{false};
+  std::atomic_bool mPendingSettingsSave{false};
+  std::atomic_uint64_t mIgnoreHotkeyUntil{0};
 
-    std::atomic_bool mExperimentalConsent{false};
-    std::atomic_bool mMaterialHudEnabled{false};
-    std::atomic_int  mMaterialHudPosition{3};
-    mutable std::mutex mActionHintMutex;
-    std::string        mActionHintText;
-    std::atomic_uint64_t mActionHintExpiry{};
+  std::atomic_bool mExperimentalConsent{false};
+  std::atomic_bool mMaterialHudEnabled{false};
+  std::atomic_int mMaterialHudPosition{3};
+  mutable std::mutex mActionHintMutex;
+  std::string mActionHintText;
+  std::atomic_uint64_t mActionHintExpiry{};
 
-    mutable std::mutex                mMaterialMutex;
-    std::atomic_bool                  mMaterialListRequested{false};
-    std::atomic_bool                  mMaterialListReady{false};
-    std::vector<MaterialRequirement>  mMaterialRequirements;
-    std::vector<MaterialRequirement>  mMaterialHudRequirements;
-    std::vector<int>                  mMaterialHudAvailability;
-    bool                              mMaterialHudReady{};
+  mutable std::mutex mMaterialMutex;
+  std::atomic_bool mMaterialListRequested{false};
+  std::atomic_bool mMaterialListReady{false};
+  std::vector<MaterialRequirement> mMaterialRequirements;
+  std::vector<MaterialRequirement> mMaterialHudRequirements;
+  std::vector<int> mMaterialHudAvailability;
+  bool mMaterialHudReady{};
 };
 
 } // namespace lholo::structure::detail

--- a/src/ui/MenuController.cpp
+++ b/src/ui/MenuController.cpp
@@ -6,9 +6,9 @@
 #include "place/PlaceHelper.h"
 #include "plugin/LHolo.h"
 #include "projection/Projection.h"
-#include "structure/StructurePaths.h"
-#include "structure/StructureLoader.h"
 #include "structure/MaterialTracker.h"
+#include "structure/StructureLoader.h"
+#include "structure/StructurePaths.h"
 #include "structure/StructureSession.h"
 #include "structure/StructureUiState.h"
 #include "structure/capture/StructureCapture.h"
@@ -18,16 +18,18 @@
 #include "ui/HotkeyFormat.h"
 #include "ui/LHoloMenu.h"
 
+
 #include <algorithm>
 #include <array>
 #include <atomic>
 #include <cmath>
-#include <cstdio>
 #include <cstddef>
+#include <cstdio>
 #include <mutex>
 #include <optional>
 #include <string>
 #include <string_view>
+
 
 #include <Windows.h>
 
@@ -37,360 +39,367 @@
 namespace lholo::ui {
 namespace {
 
-auto& logger() {
-    return LHolo::getInstance().getSelf().getLogger();
-}
+auto &logger() { return LHolo::getInstance().getSelf().getLogger(); }
 
-auto& uiState() {
-    return structure::detail::StructureUiState::getInstance();
-}
+auto &uiState() { return structure::detail::StructureUiState::getInstance(); }
 
 std::array<char, 2048> gPathBuffer{};
-bool                   gPathInitialized{};
-MenuPage               gActivePage{MenuPage::Projection};
+bool gPathInitialized{};
+MenuPage gActivePage{MenuPage::Projection};
 
-struct HotkeyDefinition { HotkeyId id; char const* label; };
-constexpr std::array<HotkeyDefinition, input::kHotkeyCount> kHotkeyDefinitions{{
-    {HotkeyId::Gui, "打开投影菜单"},
-    {HotkeyId::MoveXMinus, "结构偏移 X -1"},
-    {HotkeyId::MoveXPlus, "结构偏移 X +1"},
-    {HotkeyId::MoveZMinus, "结构偏移 Z -1"},
-    {HotkeyId::MoveZPlus, "结构偏移 Z +1"},
-    {HotkeyId::MoveYPlus, "结构偏移 Y +1"},
-    {HotkeyId::MoveYMinus, "结构偏移 Y -1"},
-    {HotkeyId::LayerIncrease, "上一层"},
-    {HotkeyId::LayerDecrease, "下一层"},
-    {HotkeyId::LoadProjection, "加载投影"},
-    {HotkeyId::CloseProjection, "关闭投影"}
-}};
+struct HotkeyDefinition {
+  HotkeyId id;
+  char const *label;
+};
+constexpr std::array<HotkeyDefinition, input::kHotkeyCount> kHotkeyDefinitions{
+    {{HotkeyId::Gui, "打开投影菜单"},
+     {HotkeyId::StructureOffset, "快捷结构偏移"},
+     {HotkeyId::MoveXMinus, "结构偏移 X -1"},
+     {HotkeyId::MoveXPlus, "结构偏移 X +1"},
+     {HotkeyId::MoveZMinus, "结构偏移 Z -1"},
+     {HotkeyId::MoveZPlus, "结构偏移 Z +1"},
+     {HotkeyId::MoveYPlus, "结构偏移 Y +1"},
+     {HotkeyId::MoveYMinus, "结构偏移 Y -1"},
+     {HotkeyId::LayerIncrease, "上一层"},
+     {HotkeyId::LayerDecrease, "下一层"},
+     {HotkeyId::LoadProjection, "加载投影"},
+     {HotkeyId::CloseProjection, "关闭投影"}}};
 
 } // namespace
 
 MenuModel buildStructureMenuModel(float effectiveUiScale) {
-    MenuModel model;
-    auto& session = structure::detail::StructureSession::getInstance();
-    auto const sessionSnapshot = session.snapshot();
-    auto const hud = uiState().hud();
-    model.page = gActivePage;
-    model.pathBuffer = gPathBuffer.data();
-    model.pathBufferSize = gPathBuffer.size();
-    model.blockOpeningInput = uiState().openingInputBlocked();
-    model.uiScale = effectiveUiScale;
-    auto const captureSnapshot = structure::capture::getSnapshot();
-    model.capture.mode = static_cast<int>(captureSnapshot.draft.mode);
-    model.captureRevision = captureSnapshot.revision;
-    model.capture.includeEntities = captureSnapshot.draft.includeEntities;
-    model.captureWorldAvailable = captureSnapshot.worldAvailable;
-    model.captureStatus = captureSnapshot.status;
-    if (captureSnapshot.draft.first) {
-        auto const& point = *captureSnapshot.draft.first;
-        model.capture.first = {true, point.x, point.y, point.z};
-    }
-    if (captureSnapshot.draft.second) {
-        auto const& point = *captureSnapshot.draft.second;
-        model.capture.second = {true, point.x, point.y, point.z};
-    }
-    model.layerAxis = std::clamp(sessionSnapshot.transform.layerAxis, 0, 1);
-    model.status = sessionSnapshot.status;
-    model.hasLoadedStructure = static_cast<bool>(sessionSnapshot.loaded);
-    model.hasSavedProjection = sessionSnapshot.saved.available;
-    model.savedAnchorX = sessionSnapshot.saved.anchorX;
-    model.savedAnchorY = sessionSnapshot.saved.anchorY;
-    model.savedAnchorZ = sessionSnapshot.saved.anchorZ;
-    model.maxLayerY = sessionSnapshot.maxLayerY;
-    model.maxLayerX = sessionSnapshot.maxLayerX;
-    model.structureBoundsEnabled = projection::getStructureBoundsEnabled();
-    model.correctionSeeThrough = projection::getCorrectionSeeThrough();
-    model.missingSeeThrough = projection::getMissingSeeThrough();
-    model.easyPlaceEnabled = place::isEnabled();
-    model.manualPlace = place::isManualMode();
-    model.rangeEnabled = place::isRangeEnabled();
-    model.experimentalConsent = structure::experimentalConsentGiven();
-    model.materialHudEnabled = structure::materialHudEnabled();
-    model.materialHudPosition = std::clamp(structure::materialHudPosition(), 0, 3);
-    model.placementRadius = place::getPlacementRadius();
-    model.autoPlacementBreakCooldownSeconds = place::getAutoPlacementBreakCooldownSeconds();
-    model.offsetX = sessionSnapshot.transform.offsetX;
-    model.offsetY = sessionSnapshot.transform.offsetY;
-    model.offsetZ = sessionSnapshot.transform.offsetZ;
-    model.rotation = std::clamp(sessionSnapshot.transform.rotation, 0, 3);
-    model.mirror = std::clamp(sessionSnapshot.transform.mirror, 0, 2);
-    model.opacity = projection::getOpacity();
-    model.correctionFillOpacity = projection::getCorrectionFillOpacity();
-    model.correctionOutlineOpacity = projection::getCorrectionOutlineOpacity();
-    model.layerDisplayMode = std::clamp(sessionSnapshot.transform.layerDisplayMode, 0, 3);
-    model.displayLayer = std::clamp(
-        sessionSnapshot.transform.displayLayer, 0,
-        model.layerAxis == 1 ? model.maxLayerX : model.maxLayerY
-    );
-    model.hudEnabled = hud.enabled;
-    model.hudPosition = std::clamp(hud.position, 0, 3);
-    model.hudShowFileName = hud.showFileName;
-    model.hudShowLayer = hud.showLayer;
-    model.hudShowOverallProgress = hud.showOverallProgress;
-    model.hudShowProgress = hud.showProgress;
-    model.hudShowWrongState = hud.showWrongState;
-    model.hudShowWrongType = hud.showWrongType;
-    model.hudShowExtraBlocks = hud.showExtraBlocks;
-    model.hudShowProjectedBlockName = hud.showProjectedBlockName;
-    std::size_t rowIndex = 0;
-    for (auto const& definition : kHotkeyDefinitions) {
-        auto const binding = uiState().hotkey(static_cast<std::size_t>(definition.id));
-        auto& row = model.hotkeys[rowIndex++];
-        row.id = definition.id;
-        row.label = definition.label;
-        row.display = hotkeyChordName(binding.modifiers, binding.key);
-        row.capturing = binding.capturing;
-    }
-    auto const materials = uiState().materialRequirements();
-    model.materials.reserve(materials.size());
-    for (auto const& material : materials) {
-        model.materials.push_back(
-            {material.displayName, material.typeName, material.count, material.stackSize}
-        );
-    }
-    return model;
+  MenuModel model;
+  auto &session = structure::detail::StructureSession::getInstance();
+  auto const sessionSnapshot = session.snapshot();
+  auto const hud = uiState().hud();
+  model.page = gActivePage;
+  model.pathBuffer = gPathBuffer.data();
+  model.pathBufferSize = gPathBuffer.size();
+  model.blockOpeningInput = uiState().openingInputBlocked();
+  model.uiScale = effectiveUiScale;
+  auto const captureSnapshot = structure::capture::getSnapshot();
+  model.capture.mode = static_cast<int>(captureSnapshot.draft.mode);
+  model.captureRevision = captureSnapshot.revision;
+  model.capture.includeEntities = captureSnapshot.draft.includeEntities;
+  model.captureWorldAvailable = captureSnapshot.worldAvailable;
+  model.captureStatus = captureSnapshot.status;
+  if (captureSnapshot.draft.first) {
+    auto const &point = *captureSnapshot.draft.first;
+    model.capture.first = {true, point.x, point.y, point.z};
+  }
+  if (captureSnapshot.draft.second) {
+    auto const &point = *captureSnapshot.draft.second;
+    model.capture.second = {true, point.x, point.y, point.z};
+  }
+  model.layerAxis = std::clamp(sessionSnapshot.transform.layerAxis, 0, 1);
+  model.status = sessionSnapshot.status;
+  model.hasLoadedStructure = static_cast<bool>(sessionSnapshot.loaded);
+  model.hasSavedProjection = sessionSnapshot.saved.available;
+  model.savedAnchorX = sessionSnapshot.saved.anchorX;
+  model.savedAnchorY = sessionSnapshot.saved.anchorY;
+  model.savedAnchorZ = sessionSnapshot.saved.anchorZ;
+  model.maxLayerY = sessionSnapshot.maxLayerY;
+  model.maxLayerX = sessionSnapshot.maxLayerX;
+  model.structureBoundsEnabled = projection::getStructureBoundsEnabled();
+  model.correctionSeeThrough = projection::getCorrectionSeeThrough();
+  model.missingSeeThrough = projection::getMissingSeeThrough();
+  model.easyPlaceEnabled = place::isEnabled();
+  model.manualPlace = place::isManualMode();
+  model.rangeEnabled = place::isRangeEnabled();
+  model.experimentalConsent = structure::experimentalConsentGiven();
+  model.materialHudEnabled = structure::materialHudEnabled();
+  model.materialHudPosition =
+      std::clamp(structure::materialHudPosition(), 0, 3);
+  model.placementRadius = place::getPlacementRadius();
+  model.autoPlacementBreakCooldownSeconds =
+      place::getAutoPlacementBreakCooldownSeconds();
+  model.offsetX = sessionSnapshot.transform.offsetX;
+  model.offsetY = sessionSnapshot.transform.offsetY;
+  model.offsetZ = sessionSnapshot.transform.offsetZ;
+  model.rotation = std::clamp(sessionSnapshot.transform.rotation, 0, 3);
+  model.mirror = std::clamp(sessionSnapshot.transform.mirror, 0, 2);
+  model.opacity = projection::getOpacity();
+  model.correctionFillOpacity = projection::getCorrectionFillOpacity();
+  model.correctionOutlineOpacity = projection::getCorrectionOutlineOpacity();
+  model.layerDisplayMode =
+      std::clamp(sessionSnapshot.transform.layerDisplayMode, 0, 3);
+  model.displayLayer =
+      std::clamp(sessionSnapshot.transform.displayLayer, 0,
+                 model.layerAxis == 1 ? model.maxLayerX : model.maxLayerY);
+  model.hudEnabled = hud.enabled;
+  model.hudPosition = std::clamp(hud.position, 0, 3);
+  model.hudShowFileName = hud.showFileName;
+  model.hudShowLayer = hud.showLayer;
+  model.hudShowOverallProgress = hud.showOverallProgress;
+  model.hudShowProgress = hud.showProgress;
+  model.hudShowWrongState = hud.showWrongState;
+  model.hudShowWrongType = hud.showWrongType;
+  model.hudShowExtraBlocks = hud.showExtraBlocks;
+  model.hudShowProjectedBlockName = hud.showProjectedBlockName;
+  std::size_t rowIndex = 0;
+  for (auto const &definition : kHotkeyDefinitions) {
+    auto const binding =
+        uiState().hotkey(static_cast<std::size_t>(definition.id));
+    auto &row = model.hotkeys[rowIndex++];
+    row.id = definition.id;
+    row.label = definition.label;
+    row.display = hotkeyChordName(binding.modifiers, binding.key);
+    row.capturing = binding.capturing;
+  }
+  auto const materials = uiState().materialRequirements();
+  model.materials.reserve(materials.size());
+  for (auto const &material : materials) {
+    model.materials.push_back({material.displayName, material.typeName,
+                               material.count, material.stackSize});
+  }
+  return model;
 }
 
-void applyStructureMenuModel(MenuModel const& model, float effectiveUiScale) {
-    bool changed = false;
-    auto& session = structure::detail::StructureSession::getInstance();
-    if (std::abs(model.uiScale - effectiveUiScale) > 0.001f) {
-        auto const scale = std::clamp(model.uiScale, 1.0f, 5.0f);
-        if (std::abs(uiState().hud().uiScale - scale) > 0.001f)
-            changed = uiState().setUiScale(scale) || changed;
-    }
-    if (projection::getStructureBoundsEnabled() != model.structureBoundsEnabled) {
-        projection::setStructureBoundsEnabled(model.structureBoundsEnabled);
-        changed = true;
-    }
-    if (projection::getCorrectionSeeThrough() != model.correctionSeeThrough) {
-        projection::setCorrectionSeeThrough(model.correctionSeeThrough);
-        changed = true;
-    }
-    if (projection::getMissingSeeThrough() != model.missingSeeThrough) {
-        projection::setMissingSeeThrough(model.missingSeeThrough);
-        changed = true;
-    }
-    // Assisted-placement modes are session-only safety controls. Applying a
-    // mode must not dirty or rewrite the persistent settings file.
-    if (place::isEnabled() != model.easyPlaceEnabled) place::setEnabled(model.easyPlaceEnabled);
-    if (place::isManualMode() != model.manualPlace) place::setManualMode(model.manualPlace);
-    if (place::isRangeEnabled() != model.rangeEnabled) place::setRangeEnabled(model.rangeEnabled);
-    auto const radius = std::clamp(model.placementRadius, 1, 4);
-    if (place::getPlacementRadius() != radius) {
-        place::setPlacementRadius(radius);
-        changed = true;
-    }
-    auto const breakCooldown = std::clamp(model.autoPlacementBreakCooldownSeconds, 0, 60);
-    if (place::getAutoPlacementBreakCooldownSeconds() != breakCooldown) {
-        place::setAutoPlacementBreakCooldownSeconds(breakCooldown);
-        changed = true;
-    }
-    changed = session.setOffsetX(model.offsetX) || changed;
-    changed = session.setOffsetY(model.offsetY) || changed;
-    changed = session.setOffsetZ(model.offsetZ) || changed;
-    changed = session.setRotation(std::clamp(model.rotation, 0, 3)) || changed;
-    changed = session.setMirror(std::clamp(model.mirror, 0, 2)) || changed;
+void applyStructureMenuModel(MenuModel const &model, float effectiveUiScale) {
+  bool changed = false;
+  auto &session = structure::detail::StructureSession::getInstance();
+  if (std::abs(model.uiScale - effectiveUiScale) > 0.001f) {
+    auto const scale = std::clamp(model.uiScale, 1.0f, 5.0f);
+    if (std::abs(uiState().hud().uiScale - scale) > 0.001f)
+      changed = uiState().setUiScale(scale) || changed;
+  }
+  if (projection::getStructureBoundsEnabled() != model.structureBoundsEnabled) {
+    projection::setStructureBoundsEnabled(model.structureBoundsEnabled);
+    changed = true;
+  }
+  if (projection::getCorrectionSeeThrough() != model.correctionSeeThrough) {
+    projection::setCorrectionSeeThrough(model.correctionSeeThrough);
+    changed = true;
+  }
+  if (projection::getMissingSeeThrough() != model.missingSeeThrough) {
+    projection::setMissingSeeThrough(model.missingSeeThrough);
+    changed = true;
+  }
+  // Assisted-placement modes are session-only safety controls. Applying a
+  // mode must not dirty or rewrite the persistent settings file.
+  if (place::isEnabled() != model.easyPlaceEnabled)
+    place::setEnabled(model.easyPlaceEnabled);
+  if (place::isManualMode() != model.manualPlace)
+    place::setManualMode(model.manualPlace);
+  if (place::isRangeEnabled() != model.rangeEnabled)
+    place::setRangeEnabled(model.rangeEnabled);
+  auto const radius = std::clamp(model.placementRadius, 1, 4);
+  if (place::getPlacementRadius() != radius) {
+    place::setPlacementRadius(radius);
+    changed = true;
+  }
+  auto const breakCooldown =
+      std::clamp(model.autoPlacementBreakCooldownSeconds, 0, 60);
+  if (place::getAutoPlacementBreakCooldownSeconds() != breakCooldown) {
+    place::setAutoPlacementBreakCooldownSeconds(breakCooldown);
+    changed = true;
+  }
+  changed = session.setOffsetX(model.offsetX) || changed;
+  changed = session.setOffsetY(model.offsetY) || changed;
+  changed = session.setOffsetZ(model.offsetZ) || changed;
+  changed = session.setRotation(std::clamp(model.rotation, 0, 3)) || changed;
+  changed = session.setMirror(std::clamp(model.mirror, 0, 2)) || changed;
 
-    auto const opacity = std::clamp(model.opacity, 0.0f, 1.0f);
-    if (std::abs(projection::getOpacity() - opacity) > 0.0001f) {
-        projection::setOpacity(opacity);
-        changed = true;
-    }
-    auto const fill = std::clamp(model.correctionFillOpacity, 0.0f, 1.0f);
-    if (std::abs(projection::getCorrectionFillOpacity() - fill) > 0.0001f) {
-        projection::setCorrectionFillOpacity(fill);
-        changed = true;
-    }
-    auto const outline = std::clamp(model.correctionOutlineOpacity, 0.0f, 1.0f);
-    if (std::abs(projection::getCorrectionOutlineOpacity() - outline) > 0.0001f) {
-        projection::setCorrectionOutlineOpacity(outline);
-        changed = true;
-    }
-    auto const layerAxis = std::clamp(model.layerAxis, 0, 1);
-    changed = session.setLayerAxis(layerAxis) || changed;
-    changed = session.setLayerDisplayMode(std::clamp(model.layerDisplayMode, 0, 3)) || changed;
-    auto const sessionSnapshot = session.snapshot();
-    auto const displayMax = layerAxis == 1 ? sessionSnapshot.maxLayerX : sessionSnapshot.maxLayerY;
-    changed = session.setDisplayLayer(std::clamp(model.displayLayer, 0, displayMax)) || changed;
-    auto hud = uiState().hud();
-    hud.enabled = model.hudEnabled;
-    hud.position = std::clamp(model.hudPosition, 0, 3);
-    hud.showFileName = model.hudShowFileName;
-    hud.showLayer = model.hudShowLayer;
-    hud.showOverallProgress = model.hudShowOverallProgress;
-    hud.showProgress = model.hudShowProgress;
-    hud.showWrongState = model.hudShowWrongState;
-    hud.showWrongType = model.hudShowWrongType;
-    hud.showExtraBlocks = model.hudShowExtraBlocks;
-    hud.showProjectedBlockName = model.hudShowProjectedBlockName;
-    changed = uiState().applyHud(hud) || changed;
-    if (structure::materialHudEnabled() != model.materialHudEnabled) {
-        structure::setMaterialHudEnabled(model.materialHudEnabled);
-        changed = true;
-    }
-    auto const materialPosition = std::clamp(model.materialHudPosition, 0, 3);
-    if (structure::materialHudPosition() != materialPosition) {
-        structure::setMaterialHudPosition(materialPosition);
-        changed = true;
-    }
-    structure::capture::Draft captureDraft;
-    captureDraft.mode = static_cast<structure::capture::CaptureMode>(
-        std::clamp(model.capture.mode, 0, 1)
-    );
-    captureDraft.includeEntities = model.capture.includeEntities;
-    if (model.capture.first.set) {
-        captureDraft.first = structure::capture::Point{
-            model.capture.first.x, model.capture.first.y, model.capture.first.z
-        };
-    }
-    if (model.capture.second.set) {
-        captureDraft.second = structure::capture::Point{
-            model.capture.second.x, model.capture.second.y, model.capture.second.z
-        };
-    }
-    structure::capture::updateDraft(captureDraft);
-    if (changed) structure::saveSettings();
+  auto const opacity = std::clamp(model.opacity, 0.0f, 1.0f);
+  if (std::abs(projection::getOpacity() - opacity) > 0.0001f) {
+    projection::setOpacity(opacity);
+    changed = true;
+  }
+  auto const fill = std::clamp(model.correctionFillOpacity, 0.0f, 1.0f);
+  if (std::abs(projection::getCorrectionFillOpacity() - fill) > 0.0001f) {
+    projection::setCorrectionFillOpacity(fill);
+    changed = true;
+  }
+  auto const outline = std::clamp(model.correctionOutlineOpacity, 0.0f, 1.0f);
+  if (std::abs(projection::getCorrectionOutlineOpacity() - outline) > 0.0001f) {
+    projection::setCorrectionOutlineOpacity(outline);
+    changed = true;
+  }
+  auto const layerAxis = std::clamp(model.layerAxis, 0, 1);
+  changed = session.setLayerAxis(layerAxis) || changed;
+  changed =
+      session.setLayerDisplayMode(std::clamp(model.layerDisplayMode, 0, 3)) ||
+      changed;
+  auto const sessionSnapshot = session.snapshot();
+  auto const displayMax =
+      layerAxis == 1 ? sessionSnapshot.maxLayerX : sessionSnapshot.maxLayerY;
+  changed =
+      session.setDisplayLayer(std::clamp(model.displayLayer, 0, displayMax)) ||
+      changed;
+  auto hud = uiState().hud();
+  hud.enabled = model.hudEnabled;
+  hud.position = std::clamp(model.hudPosition, 0, 3);
+  hud.showFileName = model.hudShowFileName;
+  hud.showLayer = model.hudShowLayer;
+  hud.showOverallProgress = model.hudShowOverallProgress;
+  hud.showProgress = model.hudShowProgress;
+  hud.showWrongState = model.hudShowWrongState;
+  hud.showWrongType = model.hudShowWrongType;
+  hud.showExtraBlocks = model.hudShowExtraBlocks;
+  hud.showProjectedBlockName = model.hudShowProjectedBlockName;
+  changed = uiState().applyHud(hud) || changed;
+  if (structure::materialHudEnabled() != model.materialHudEnabled) {
+    structure::setMaterialHudEnabled(model.materialHudEnabled);
+    changed = true;
+  }
+  auto const materialPosition = std::clamp(model.materialHudPosition, 0, 3);
+  if (structure::materialHudPosition() != materialPosition) {
+    structure::setMaterialHudPosition(materialPosition);
+    changed = true;
+  }
+  structure::capture::Draft captureDraft;
+  captureDraft.mode = static_cast<structure::capture::CaptureMode>(
+      std::clamp(model.capture.mode, 0, 1));
+  captureDraft.includeEntities = model.capture.includeEntities;
+  if (model.capture.first.set) {
+    captureDraft.first = structure::capture::Point{
+        model.capture.first.x, model.capture.first.y, model.capture.first.z};
+  }
+  if (model.capture.second.set) {
+    captureDraft.second = structure::capture::Point{
+        model.capture.second.x, model.capture.second.y, model.capture.second.z};
+  }
+  structure::capture::updateDraft(captureDraft);
+  if (changed)
+    structure::saveSettings();
 }
 
-MenuActions buildStructureMenuActions(bool& refreshModel) {
-    MenuActions actions;
-    actions.browseStructure = [](std::string_view current) -> std::optional<std::string> {
-        auto const selected = openStructureFile(structure::detail::pathFromUtf8(current));
-        return selected ? std::optional<std::string>{structure::detail::pathToUtf8(*selected)}
-                        : std::nullopt;
-    };
-    actions.loadStructure = [&refreshModel](std::string_view pathValue) {
-        auto& session = structure::detail::StructureSession::getInstance();
-        auto const pathText = std::string{pathValue};
-        if (pathText.empty()) {
-            session.setStatus("请选择或输入 .mcstructure / .litematic 文件路径");
-            return;
-        }
-        std::string error;
-        auto loaded = structure::detail::loadStructureFile(
-            structure::detail::pathFromUtf8(pathText), error
-        );
-        if (!loaded) {
-            session.setStatus("加载失败: " + error);
-            logger().error("Could not load structure {}: {}", pathText, error);
-            return;
-        }
-        auto const status = structure::detail::makeStructureStatus(*loaded);
-        // A normal file load is a new user intent. Do not let an unconsumed
-        // restore request from an earlier failed/pending activation move it.
-        projection::cancelNextStructureAnchorRequest();
-        session.replaceLoaded(std::move(loaded), pathText, status);
-        structure::detail::invalidateMaterialList();
-        structure::saveSettings();
-        refreshModel = true;
-        logger().info("{}", status);
-    };
-    actions.restoreProjection = [&refreshModel] {
-        structure::restoreSavedProjection();
-        auto const savedPath =
-            structure::detail::StructureSession::getInstance().savedProjection().structurePath;
-        std::snprintf(gPathBuffer.data(), gPathBuffer.size(), "%s", savedPath.c_str());
-        refreshModel = true;
-    };
-    actions.closeProjection = [&refreshModel] {
-        structure::clear();
-        // clear() freezes the active transform before releasing the loaded
-        // structure; persist that restore snapshot while closing from the UI.
-        structure::saveSettings();
-        refreshModel = true;
-    };
-    actions.requestMaterials = [] { structure::requestMaterialList(); };
-    actions.beginHotkeyCapture = [](HotkeyId id) {
-        uiState().beginHotkeyCapture(static_cast<std::size_t>(id));
-    };
-    actions.clearHotkey = [](HotkeyId id) {
-        uiState().clearHotkey(static_cast<std::size_t>(id));
-        structure::saveSettings();
-    };
-    actions.resetHotkeys = [] {
-        uiState().resetHotkeys();
-        structure::resetHotkeyState();
-        structure::saveSettings();
-    };
-    actions.resetCorrectionStyle = [] {
-        projection::setCorrectionFillOpacity(0.15f);
-        projection::setCorrectionOutlineOpacity(1.0f);
-        structure::saveSettings();
-    };
-    actions.giveExperimentalConsent = [] {
-        structure::setExperimentalConsentGiven(true);
-        structure::saveSettings();
-    };
-    actions.usePlayerCapturePosition = [&refreshModel](CapturePointId point) {
-        structure::capture::setPointFromPlayer(
-            point == CapturePointId::First
-                ? structure::capture::PointSlot::First
-                : structure::capture::PointSlot::Second
-        );
-        refreshModel = true;
-    };
-    actions.clearCapture = [&refreshModel] {
-        structure::capture::clear();
-        refreshModel = true;
-    };
-    actions.exportCapture = [&refreshModel](CaptureDraftModel const& model) {
-        auto const output = saveMcstructureFile();
-        if (!output) return;
-        structure::capture::Draft draft;
-        draft.mode = static_cast<structure::capture::CaptureMode>(
-            std::clamp(model.mode, 0, 1)
-        );
-        draft.includeEntities = model.includeEntities;
-        if (model.first.set) {
-            draft.first = structure::capture::Point{
-                model.first.x, model.first.y, model.first.z
-            };
-        }
-        if (model.second.set) {
-            draft.second = structure::capture::Point{
-                model.second.x, model.second.y, model.second.z
-            };
-        }
-        structure::capture::exportStructure(draft, *output);
-        refreshModel = true;
-    };
-    return actions;
+MenuActions buildStructureMenuActions(bool &refreshModel) {
+  MenuActions actions;
+  actions.browseStructure =
+      [](std::string_view current) -> std::optional<std::string> {
+    auto const selected =
+        openStructureFile(structure::detail::pathFromUtf8(current));
+    return selected ? std::optional<std::string>{structure::detail::pathToUtf8(
+                          *selected)}
+                    : std::nullopt;
+  };
+  actions.loadStructure = [&refreshModel](std::string_view pathValue) {
+    auto &session = structure::detail::StructureSession::getInstance();
+    auto const pathText = std::string{pathValue};
+    if (pathText.empty()) {
+      session.setStatus("请选择或输入 .mcstructure / .litematic 文件路径");
+      return;
+    }
+    std::string error;
+    auto loaded = structure::detail::loadStructureFile(
+        structure::detail::pathFromUtf8(pathText), error);
+    if (!loaded) {
+      session.setStatus("加载失败: " + error);
+      logger().error("Could not load structure {}: {}", pathText, error);
+      return;
+    }
+    auto const status = structure::detail::makeStructureStatus(*loaded);
+    // A normal file load is a new user intent. Do not let an unconsumed
+    // restore request from an earlier failed/pending activation move it.
+    projection::cancelNextStructureAnchorRequest();
+    session.replaceLoaded(std::move(loaded), pathText, status);
+    structure::detail::invalidateMaterialList();
+    structure::saveSettings();
+    refreshModel = true;
+    logger().info("{}", status);
+  };
+  actions.restoreProjection = [&refreshModel] {
+    structure::restoreSavedProjection();
+    auto const savedPath = structure::detail::StructureSession::getInstance()
+                               .savedProjection()
+                               .structurePath;
+    std::snprintf(gPathBuffer.data(), gPathBuffer.size(), "%s",
+                  savedPath.c_str());
+    refreshModel = true;
+  };
+  actions.closeProjection = [&refreshModel] {
+    structure::clear();
+    // clear() freezes the active transform before releasing the loaded
+    // structure; persist that restore snapshot while closing from the UI.
+    structure::saveSettings();
+    refreshModel = true;
+  };
+  actions.requestMaterials = [] { structure::requestMaterialList(); };
+  actions.beginHotkeyCapture = [](HotkeyId id) {
+    uiState().beginHotkeyCapture(static_cast<std::size_t>(id));
+  };
+  actions.clearHotkey = [](HotkeyId id) {
+    uiState().clearHotkey(static_cast<std::size_t>(id));
+    structure::saveSettings();
+  };
+  actions.resetHotkeys = [] {
+    uiState().resetHotkeys();
+    structure::resetHotkeyState();
+    structure::saveSettings();
+  };
+  actions.resetCorrectionStyle = [] {
+    projection::setCorrectionFillOpacity(0.15f);
+    projection::setCorrectionOutlineOpacity(1.0f);
+    structure::saveSettings();
+  };
+  actions.giveExperimentalConsent = [] {
+    structure::setExperimentalConsentGiven(true);
+    structure::saveSettings();
+  };
+  actions.usePlayerCapturePosition = [&refreshModel](CapturePointId point) {
+    structure::capture::setPointFromPlayer(
+        point == CapturePointId::First ? structure::capture::PointSlot::First
+                                       : structure::capture::PointSlot::Second);
+    refreshModel = true;
+  };
+  actions.clearCapture = [&refreshModel] {
+    structure::capture::clear();
+    refreshModel = true;
+  };
+  actions.exportCapture = [&refreshModel](CaptureDraftModel const &model) {
+    auto const output = saveMcstructureFile();
+    if (!output)
+      return;
+    structure::capture::Draft draft;
+    draft.mode = static_cast<structure::capture::CaptureMode>(
+        std::clamp(model.mode, 0, 1));
+    draft.includeEntities = model.includeEntities;
+    if (model.first.set) {
+      draft.first = structure::capture::Point{model.first.x, model.first.y,
+                                              model.first.z};
+    }
+    if (model.second.set) {
+      draft.second = structure::capture::Point{model.second.x, model.second.y,
+                                               model.second.z};
+    }
+    structure::capture::exportStructure(draft, *output);
+    refreshModel = true;
+  };
+  return actions;
 }
 
 void renderStructureMenu() {
-    if (!structure::isGuiVisible()) return;
-    auto const displaySize = ImGui::GetIO().DisplaySize;
-    auto const configuredScale = uiState().hud().uiScale;
-    auto const effectiveScale = configuredScale > 0.0f
-        ? std::clamp(configuredScale, 1.0f, 5.0f)
-        : std::clamp(
-            std::min(displaySize.x / 1920.0f, displaySize.y / 1080.0f), 1.0f, 5.0f
-        );
-    if (!gPathInitialized) {
-        auto const lastPath = structure::detail::StructureSession::getInstance().lastPath();
-        std::snprintf(
-            gPathBuffer.data(),
-            gPathBuffer.size(),
-            "%s",
-            lastPath.c_str()
-        );
-        gPathInitialized = true;
-    }
-    auto const metrics = calculateMetrics(displaySize, effectiveScale);
-    applyFluentTheme(metrics);
-    auto model = buildStructureMenuModel(effectiveScale);
-    bool refreshModel = false;
-    auto const actions = buildStructureMenuActions(refreshModel);
-    renderMenu(model, actions, metrics);
-    gActivePage = model.page;
-    if (!refreshModel) applyStructureMenuModel(model, effectiveScale);
-    uiState().consumeOpeningInputBlockFrame();
-    if (model.closeRequested) {
-        uiState().setGuiVisible(false);
-        uiState().setBlockGameInputUntil(GetTickCount64() + 180);
-    }
+  if (!structure::isGuiVisible())
+    return;
+  auto const displaySize = ImGui::GetIO().DisplaySize;
+  auto const configuredScale = uiState().hud().uiScale;
+  auto const effectiveScale =
+      configuredScale > 0.0f ? std::clamp(configuredScale, 1.0f, 5.0f)
+                             : std::clamp(std::min(displaySize.x / 1920.0f,
+                                                   displaySize.y / 1080.0f),
+                                          1.0f, 5.0f);
+  if (!gPathInitialized) {
+    auto const lastPath =
+        structure::detail::StructureSession::getInstance().lastPath();
+    std::snprintf(gPathBuffer.data(), gPathBuffer.size(), "%s",
+                  lastPath.c_str());
+    gPathInitialized = true;
+  }
+  auto const metrics = calculateMetrics(displaySize, effectiveScale);
+  applyFluentTheme(metrics);
+  auto model = buildStructureMenuModel(effectiveScale);
+  bool refreshModel = false;
+  auto const actions = buildStructureMenuActions(refreshModel);
+  renderMenu(model, actions, metrics);
+  gActivePage = model.page;
+  if (!refreshModel)
+    applyStructureMenuModel(model, effectiveScale);
+  uiState().consumeOpeningInputBlockFrame();
+  if (model.closeRequested) {
+    uiState().setGuiVisible(false);
+    uiState().setBlockGameInputUntil(GetTickCount64() + 180);
+  }
 }
 
 } // namespace lholo::ui

--- a/tests/logic/LogicTests.cpp
+++ b/tests/logic/LogicTests.cpp
@@ -10,6 +10,7 @@
 #include "projection/core/ProjectionRules.h"
 #include "projection/runtime/ProjectionProgress.h"
 #include "settings/SettingsStore.h"
+#include "structure/StructureLoader.h"
 #include "structure/StructureSession.h"
 #include "structure/StructureUiState.h"
 #include "structure/java_to_bedrock/JavaBlockEntityToBedrock.h"
@@ -22,610 +23,692 @@ namespace {
 int gChecks = 0;
 int gFailures = 0;
 
-#define LHOLO_CHECK(cond)                                     \
-    do {                                                      \
-        ++gChecks;                                            \
-        if (!(cond)) {                                        \
-            ++gFailures;                                      \
-            std::fprintf(stderr, "FAIL %s:%d: %s\n",          \
-                __FILE__, __LINE__, #cond);                   \
-        }                                                     \
-    } while (false)
+#define LHOLO_CHECK(cond)                                                      \
+  do {                                                                         \
+    ++gChecks;                                                                 \
+    if (!(cond)) {                                                             \
+      ++gFailures;                                                             \
+      std::fprintf(stderr, "FAIL %s:%d: %s\n", __FILE__, __LINE__, #cond);     \
+    }                                                                          \
+  } while (false)
 
 using namespace lholo::projection::detail;
 using lholo::structure::LoadedStructure;
 
-bool expectBlockPos(BlockPos const& pos, int x, int y, int z) {
-    return pos.x == x && pos.y == y && pos.z == z;
+bool expectBlockPos(BlockPos const &pos, int x, int y, int z) {
+  return pos.x == x && pos.y == y && pos.z == z;
 }
 
 void testLayoutRules() {
-    LHOLO_CHECK(getProjectionMirror(0) == Mirror::None);
-    LHOLO_CHECK(getProjectionMirror(1) == Mirror::Z);
-    LHOLO_CHECK(getProjectionMirror(2) == Mirror::X);
-    LHOLO_CHECK(getProjectionMirror(9) == Mirror::None);
+  LHOLO_CHECK(getProjectionMirror(0) == Mirror::None);
+  LHOLO_CHECK(getProjectionMirror(1) == Mirror::Z);
+  LHOLO_CHECK(getProjectionMirror(2) == Mirror::X);
+  LHOLO_CHECK(getProjectionMirror(9) == Mirror::None);
 
-    LHOLO_CHECK(getProjectionRotation(0) == Rotation::None);
-    LHOLO_CHECK(getProjectionRotation(1) == Rotation::Clockwise90);
-    LHOLO_CHECK(getProjectionRotation(2) == Rotation::Clockwise180);
-    LHOLO_CHECK(getProjectionRotation(3) == Rotation::CounterClockwise90);
-    LHOLO_CHECK(getProjectionRotation(4) == Rotation::None);
-    LHOLO_CHECK(getProjectionRotation(5) == Rotation::Clockwise90);
-    LHOLO_CHECK(getProjectionRotation(-1) == Rotation::CounterClockwise90);
+  LHOLO_CHECK(getProjectionRotation(0) == Rotation::None);
+  LHOLO_CHECK(getProjectionRotation(1) == Rotation::Clockwise90);
+  LHOLO_CHECK(getProjectionRotation(2) == Rotation::Clockwise180);
+  LHOLO_CHECK(getProjectionRotation(3) == Rotation::CounterClockwise90);
+  LHOLO_CHECK(getProjectionRotation(4) == Rotation::None);
+  LHOLO_CHECK(getProjectionRotation(5) == Rotation::Clockwise90);
+  LHOLO_CHECK(getProjectionRotation(-1) == Rotation::CounterClockwise90);
 
-    LoadedStructure loaded;
-    loaded.sizeX = 4;
-    loaded.sizeY = 3;
-    loaded.sizeZ = 5;
-    LoadedStructure::RenderBlock const entry{1, 2, 3, nullptr, nullptr, nullptr};
+  LoadedStructure loaded;
+  loaded.sizeX = 4;
+  loaded.sizeY = 3;
+  loaded.sizeZ = 5;
+  LoadedStructure::RenderBlock const entry{1, 2, 3, nullptr, nullptr, nullptr};
 
-    LHOLO_CHECK(expectBlockPos(transformStructurePosition(entry, loaded, 0, 0), 1, 2, 3));
-    LHOLO_CHECK(expectBlockPos(transformStructurePosition(entry, loaded, 1, 0), 2, 2, 3));
-    LHOLO_CHECK(expectBlockPos(transformStructurePosition(entry, loaded, 2, 0), 1, 2, 1));
-    LHOLO_CHECK(expectBlockPos(transformStructurePosition(entry, loaded, 0, 1), 1, 2, 1));
-    LHOLO_CHECK(expectBlockPos(transformStructurePosition(entry, loaded, 0, 2), 2, 2, 1));
-    LHOLO_CHECK(expectBlockPos(transformStructurePosition(entry, loaded, 0, 3), 3, 2, 2));
-    LHOLO_CHECK(expectBlockPos(transformStructurePosition(entry, loaded, 1, 1), 1, 2, 2));
+  LHOLO_CHECK(
+      expectBlockPos(transformStructurePosition(entry, loaded, 0, 0), 1, 2, 3));
+  LHOLO_CHECK(
+      expectBlockPos(transformStructurePosition(entry, loaded, 1, 0), 2, 2, 3));
+  LHOLO_CHECK(
+      expectBlockPos(transformStructurePosition(entry, loaded, 2, 0), 1, 2, 1));
+  LHOLO_CHECK(
+      expectBlockPos(transformStructurePosition(entry, loaded, 0, 1), 1, 2, 1));
+  LHOLO_CHECK(
+      expectBlockPos(transformStructurePosition(entry, loaded, 0, 2), 2, 2, 1));
+  LHOLO_CHECK(
+      expectBlockPos(transformStructurePosition(entry, loaded, 0, 3), 3, 2, 2));
+  LHOLO_CHECK(
+      expectBlockPos(transformStructurePosition(entry, loaded, 1, 1), 1, 2, 2));
 
-    for (int mirror = 0; mirror <= 2; ++mirror) {
-        for (int rotation = 0; rotation < 4; ++rotation) {
-            for (int x = 0; x < loaded.sizeX; ++x) {
-                for (int z = 0; z < loaded.sizeZ; ++z) {
-                    BlockPos const local{x, 1, z};
-                    auto const transformed = transformStructurePosition(
-                        local, loaded, mirror, rotation
-                    );
-                    auto const restored = inverseTransformStructurePosition(
-                        transformed, loaded, mirror, rotation
-                    );
-                    LHOLO_CHECK(expectBlockPos(restored, x, 1, z));
-                }
-            }
+  for (int mirror = 0; mirror <= 2; ++mirror) {
+    for (int rotation = 0; rotation < 4; ++rotation) {
+      for (int x = 0; x < loaded.sizeX; ++x) {
+        for (int z = 0; z < loaded.sizeZ; ++z) {
+          BlockPos const local{x, 1, z};
+          auto const transformed =
+              transformStructurePosition(local, loaded, mirror, rotation);
+          auto const restored = inverseTransformStructurePosition(
+              transformed, loaded, mirror, rotation);
+          LHOLO_CHECK(expectBlockPos(restored, x, 1, z));
         }
+      }
     }
+  }
 
-    loaded.regions = {
-        {0, 0, 0, 2, 3, 2},
-        {3, 0, 3, 1, 1, 2},
-    };
-    LHOLO_CHECK(isStructureCellCovered(loaded, BlockPos{1, 2, 1}));
-    LHOLO_CHECK(isStructureCellCovered(loaded, BlockPos{3, 0, 4}));
-    LHOLO_CHECK(!isStructureCellCovered(loaded, BlockPos{2, 0, 2}));
-    LHOLO_CHECK(!isStructureCellCovered(loaded, BlockPos{4, 0, 4}));
+  loaded.regions = {
+      {0, 0, 0, 2, 3, 2},
+      {3, 0, 3, 1, 1, 2},
+  };
+  LHOLO_CHECK(isStructureCellCovered(loaded, BlockPos{1, 2, 1}));
+  LHOLO_CHECK(isStructureCellCovered(loaded, BlockPos{3, 0, 4}));
+  LHOLO_CHECK(!isStructureCellCovered(loaded, BlockPos{2, 0, 2}));
+  LHOLO_CHECK(!isStructureCellCovered(loaded, BlockPos{4, 0, 4}));
 
-    LHOLO_CHECK(isLayerVisible(3, 0, 0));
-    LHOLO_CHECK(!isLayerVisible(3, 1, 2));
-    LHOLO_CHECK(isLayerVisible(2, 1, 2));
-    LHOLO_CHECK(isLayerVisible(2, 2, 3));
-    LHOLO_CHECK(!isLayerVisible(4, 2, 3));
-    LHOLO_CHECK(isLayerVisible(4, 3, 3));
-    LHOLO_CHECK(!isLayerVisible(2, 3, 3));
+  LHOLO_CHECK(isLayerVisible(3, 0, 0));
+  LHOLO_CHECK(!isLayerVisible(3, 1, 2));
+  LHOLO_CHECK(isLayerVisible(2, 1, 2));
+  LHOLO_CHECK(isLayerVisible(2, 2, 3));
+  LHOLO_CHECK(!isLayerVisible(4, 2, 3));
+  LHOLO_CHECK(isLayerVisible(4, 3, 3));
+  LHOLO_CHECK(!isLayerVisible(2, 3, 3));
 
-    LHOLO_CHECK(renderBucketFor(BlockRenderLayer::RenderlayerOpaque) == RenderBucket::Opaque);
-    LHOLO_CHECK(renderBucketFor(BlockRenderLayer::RenderlayerSeasonsOpaque) == RenderBucket::Opaque);
-    LHOLO_CHECK(renderBucketFor(BlockRenderLayer::RenderlayerBlend) == RenderBucket::Blend);
-    LHOLO_CHECK(renderBucketFor(BlockRenderLayer::RenderlayerBlendToOpaque) == RenderBucket::Blend);
-    LHOLO_CHECK(renderBucketFor(BlockRenderLayer::RenderlayerAlphatestSingleSide) == RenderBucket::AlphaOneSided);
-    LHOLO_CHECK(renderBucketFor(BlockRenderLayer::RenderlayerAlphatest) == RenderBucket::Alpha);
-    LHOLO_CHECK(renderBucketFor(BlockRenderLayer::RenderlayerDoubleSided) == RenderBucket::Alpha);
+  LHOLO_CHECK(renderBucketFor(BlockRenderLayer::RenderlayerOpaque) ==
+              RenderBucket::Opaque);
+  LHOLO_CHECK(renderBucketFor(BlockRenderLayer::RenderlayerSeasonsOpaque) ==
+              RenderBucket::Opaque);
+  LHOLO_CHECK(renderBucketFor(BlockRenderLayer::RenderlayerBlend) ==
+              RenderBucket::Blend);
+  LHOLO_CHECK(renderBucketFor(BlockRenderLayer::RenderlayerBlendToOpaque) ==
+              RenderBucket::Blend);
+  LHOLO_CHECK(
+      renderBucketFor(BlockRenderLayer::RenderlayerAlphatestSingleSide) ==
+      RenderBucket::AlphaOneSided);
+  LHOLO_CHECK(renderBucketFor(BlockRenderLayer::RenderlayerAlphatest) ==
+              RenderBucket::Alpha);
+  LHOLO_CHECK(renderBucketFor(BlockRenderLayer::RenderlayerDoubleSided) ==
+              RenderBucket::Alpha);
 }
 
 void testProgress() {
-    initializePublishedBuildProgress(100);
-    auto progress = getPublishedBuildProgress();
-    LHOLO_CHECK(progress.total == 100);
-    LHOLO_CHECK(progress.visibleTotal == 100);
-    LHOLO_CHECK(progress.placed == 0);
+  initializePublishedBuildProgress(100);
+  auto progress = getPublishedBuildProgress();
+  LHOLO_CHECK(progress.total == 100);
+  LHOLO_CHECK(progress.visibleTotal == 100);
+  LHOLO_CHECK(progress.placed == 0);
 
-    publishPlacedProgress(120);
-    progress = getPublishedBuildProgress();
-    LHOLO_CHECK(progress.placed == 100);
+  publishPlacedProgress(120);
+  progress = getPublishedBuildProgress();
+  LHOLO_CHECK(progress.placed == 100);
 
-    publishVisibleProgress(60, 80);
-    publishErrorProgress(130, 5, 140);
-    progress = getPublishedBuildProgress();
-    LHOLO_CHECK(progress.visiblePlaced == 60);
-    LHOLO_CHECK(progress.visibleTotal == 80);
-    LHOLO_CHECK(progress.wrongType == 100);
-    LHOLO_CHECK(progress.wrongState == 5);
-    LHOLO_CHECK(progress.extra == 140);
+  publishVisibleProgress(60, 80);
+  publishErrorProgress(130, 5, 140);
+  progress = getPublishedBuildProgress();
+  LHOLO_CHECK(progress.visiblePlaced == 60);
+  LHOLO_CHECK(progress.visibleTotal == 80);
+  LHOLO_CHECK(progress.wrongType == 100);
+  LHOLO_CHECK(progress.wrongState == 5);
+  LHOLO_CHECK(progress.extra == 140);
 
-    resetPublishedBuildProgress();
-    progress = getPublishedBuildProgress();
-    LHOLO_CHECK(progress.total == 0);
-    LHOLO_CHECK(progress.placed == 0);
-    LHOLO_CHECK(progress.visibleTotal == 0);
+  resetPublishedBuildProgress();
+  progress = getPublishedBuildProgress();
+  LHOLO_CHECK(progress.total == 0);
+  LHOLO_CHECK(progress.placed == 0);
+  LHOLO_CHECK(progress.visibleTotal == 0);
 
-    initializePublishedBuildProgress(50);
-    publishVisibleProgress(40, 30);
-    progress = getPublishedBuildProgress();
-    LHOLO_CHECK(progress.visiblePlaced == 30);
-    LHOLO_CHECK(progress.total == 50);
+  initializePublishedBuildProgress(50);
+  publishVisibleProgress(40, 30);
+  progress = getPublishedBuildProgress();
+  LHOLO_CHECK(progress.visiblePlaced == 30);
+  LHOLO_CHECK(progress.total == 50);
 
-    resetPublishedBuildProgressCounts();
-    progress = getPublishedBuildProgress();
-    LHOLO_CHECK(progress.total == 50);
-    LHOLO_CHECK(progress.placed == 0);
-    LHOLO_CHECK(progress.wrongType == 0);
-    LHOLO_CHECK(progress.wrongState == 0);
-    LHOLO_CHECK(progress.extra == 0);
+  resetPublishedBuildProgressCounts();
+  progress = getPublishedBuildProgress();
+  LHOLO_CHECK(progress.total == 50);
+  LHOLO_CHECK(progress.placed == 0);
+  LHOLO_CHECK(progress.wrongType == 0);
+  LHOLO_CHECK(progress.wrongState == 0);
+  LHOLO_CHECK(progress.extra == 0);
 }
 
 void testSettingsStore() {
-    auto const path = std::filesystem::temp_directory_path() / "lholo_settings_test.json";
-    std::error_code error;
-    std::filesystem::remove(path, error);
+  auto const path =
+      std::filesystem::temp_directory_path() / "lholo_settings_test.json";
+  std::error_code error;
+  std::filesystem::remove(path, error);
 
-    lholo::settings::Settings settings;
-    settings.uiScale = 1.25f;
-    settings.guiHotkey = 'L';
-    settings.guiHotkeyModifiers = 1;
-    settings.hudShowProjectedBlockName = false;
-    settings.hudShowExtraBlocks = false;
-    settings.autoPlacementBreakCooldownSeconds = 27;
-    settings.correctionSeeThrough = true;
-    settings.materialHudEnabled = true;
-    settings.materialHudPosition = 3;
-    settings.moveHotkeys[4] = 0x57; // W
-    settings.hasSavedProjection = true;
-    settings.savedAnchorX = 12;
-    settings.savedAnchorZ = -34;
-    lholo::settings::saveSettingsFile(path, settings);
-    {
-        std::ifstream saved(path);
-        std::ostringstream contents;
-        contents << saved.rdbuf();
-        LHOLO_CHECK(contents.str().find("\"version\": 11") != std::string::npos);
-        LHOLO_CHECK(contents.str().find("toggleManualHotkey") == std::string::npos);
-        LHOLO_CHECK(contents.str().find("toggleEasyHotkey") == std::string::npos);
-        LHOLO_CHECK(contents.str().find("toggleRangeHotkey") == std::string::npos);
-    }
+  lholo::settings::Settings settings;
+  settings.uiScale = 1.25f;
+  settings.guiHotkey = 'L';
+  settings.guiHotkeyModifiers = 1;
+  settings.structureOffsetHotkey = VK_LMENU;
+  settings.structureOffsetHotkeyModifiers = 0;
+  settings.hudShowProjectedBlockName = false;
+  settings.hudShowExtraBlocks = false;
+  settings.autoPlacementBreakCooldownSeconds = 27;
+  settings.correctionSeeThrough = true;
+  settings.materialHudEnabled = true;
+  settings.materialHudPosition = 3;
+  settings.moveHotkeys[4] = 0x57; // W
+  settings.hasSavedProjection = true;
+  settings.savedAnchorX = 12;
+  settings.savedAnchorZ = -34;
+  lholo::settings::saveSettingsFile(path, settings);
+  {
+    std::ifstream saved(path);
+    std::ostringstream contents;
+    contents << saved.rdbuf();
+    LHOLO_CHECK(contents.str().find("\"version\": 11") != std::string::npos);
+    LHOLO_CHECK(contents.str().find("toggleManualHotkey") == std::string::npos);
+    LHOLO_CHECK(contents.str().find("toggleEasyHotkey") == std::string::npos);
+    LHOLO_CHECK(contents.str().find("toggleRangeHotkey") == std::string::npos);
+  }
 
-    lholo::settings::Settings loaded;
-    LHOLO_CHECK(lholo::settings::loadSettingsFile(path, loaded));
-    LHOLO_CHECK(loaded.uiScale == 1.25f);
-    LHOLO_CHECK(loaded.guiHotkey == 'L');
-    LHOLO_CHECK(loaded.guiHotkeyModifiers == 1);
-    LHOLO_CHECK(!loaded.hudShowProjectedBlockName);
-    LHOLO_CHECK(!loaded.hudShowExtraBlocks);
-    LHOLO_CHECK(loaded.autoPlacementBreakCooldownSeconds == 27);
-    LHOLO_CHECK(loaded.correctionSeeThrough);
-    LHOLO_CHECK(loaded.materialHudEnabled);
-    LHOLO_CHECK(loaded.materialHudPosition == 3);
-    LHOLO_CHECK(loaded.moveHotkeys[4] == 0x57);
-    LHOLO_CHECK(loaded.hasSavedProjection);
-    LHOLO_CHECK(loaded.savedAnchorX == 12);
-    LHOLO_CHECK(loaded.savedAnchorZ == -34);
+  lholo::settings::Settings loaded;
+  LHOLO_CHECK(lholo::settings::loadSettingsFile(path, loaded));
+  LHOLO_CHECK(loaded.uiScale == 1.25f);
+  LHOLO_CHECK(loaded.guiHotkey == 'L');
+  LHOLO_CHECK(loaded.guiHotkeyModifiers == 1);
+  LHOLO_CHECK(loaded.structureOffsetHotkey == VK_LMENU);
+  LHOLO_CHECK(loaded.structureOffsetHotkeyModifiers == 0);
+  LHOLO_CHECK(!loaded.hudShowProjectedBlockName);
+  LHOLO_CHECK(!loaded.hudShowExtraBlocks);
+  LHOLO_CHECK(loaded.autoPlacementBreakCooldownSeconds == 27);
+  LHOLO_CHECK(loaded.correctionSeeThrough);
+  LHOLO_CHECK(loaded.materialHudEnabled);
+  LHOLO_CHECK(loaded.materialHudPosition == 3);
+  LHOLO_CHECK(loaded.moveHotkeys[4] == 0x57);
+  LHOLO_CHECK(loaded.hasSavedProjection);
+  LHOLO_CHECK(loaded.savedAnchorX == 12);
+  LHOLO_CHECK(loaded.savedAnchorZ == -34);
 
-    // Existing configs keep their preference when the old, narrower
-    // block-entity label migrates to the projected-block label.
-    {
-        std::ofstream legacy(path, std::ios::trunc);
-        legacy << R"({"hudShowBlockEntity":false,"toggleManualHotkey":82,"toggleEasyHotkey":70,"toggleRangeHotkey":89})";
-    }
-    lholo::settings::Settings migrated;
-    LHOLO_CHECK(lholo::settings::loadSettingsFile(path, migrated));
-    LHOLO_CHECK(!migrated.hudShowProjectedBlockName);
-    LHOLO_CHECK(migrated.hudShowExtraBlocks);
-    LHOLO_CHECK(migrated.autoPlacementBreakCooldownSeconds == 10);
-    LHOLO_CHECK(!migrated.correctionSeeThrough);
-    LHOLO_CHECK(!migrated.materialHudEnabled);
-    LHOLO_CHECK(migrated.materialHudPosition == 3);
+  // Existing configs keep their preference when the old, narrower
+  // block-entity label migrates to the projected-block label.
+  {
+    std::ofstream legacy(path, std::ios::trunc);
+    legacy
+        << R"({"hudShowBlockEntity":false,"toggleManualHotkey":82,"toggleEasyHotkey":70,"toggleRangeHotkey":89})";
+  }
+  lholo::settings::Settings migrated;
+  LHOLO_CHECK(lholo::settings::loadSettingsFile(path, migrated));
+  LHOLO_CHECK(!migrated.hudShowProjectedBlockName);
+  LHOLO_CHECK(migrated.hudShowExtraBlocks);
+  LHOLO_CHECK(migrated.autoPlacementBreakCooldownSeconds == 10);
+  LHOLO_CHECK(!migrated.correctionSeeThrough);
+  LHOLO_CHECK(!migrated.materialHudEnabled);
+  LHOLO_CHECK(migrated.materialHudPosition == 3);
 
-    lholo::settings::Settings missing;
-    std::filesystem::remove(path, error);
-    LHOLO_CHECK(!lholo::settings::loadSettingsFile(path, missing));
-    std::filesystem::remove(path, error);
+  lholo::settings::Settings missing;
+  std::filesystem::remove(path, error);
+  LHOLO_CHECK(!lholo::settings::loadSettingsFile(path, missing));
+  std::filesystem::remove(path, error);
+}
+
+void testOffsetPreviewDelay() {
+  auto &uiState = lholo::structure::detail::StructureUiState::getInstance();
+  uiState.resetWorldSession();
+
+  uiState.queueOffsetDelta(1, 2, 3);
+  auto const pending = uiState.consumePendingHotkeyActions();
+  LHOLO_CHECK(pending.offsetX == 1);
+  LHOLO_CHECK(pending.offsetY == 2);
+  LHOLO_CHECK(pending.offsetZ == 3);
+
+  uiState.addOffsetPreview(pending.offsetX, pending.offsetY, pending.offsetZ);
+  auto const preview = uiState.offsetPreview();
+  LHOLO_CHECK(preview[0] == 1);
+  LHOLO_CHECK(preview[1] == 2);
+  LHOLO_CHECK(preview[2] == 3);
+
+  uiState.setOffsetPreviewDeadline(GetTickCount64() - 1);
+  auto const committed = uiState.consumeOffsetPreview();
+  LHOLO_CHECK(committed[0] == 1);
+  LHOLO_CHECK(committed[1] == 2);
+  LHOLO_CHECK(committed[2] == 3);
+  LHOLO_CHECK(!uiState.offsetPreviewActive());
+}
+
+void testWheelOffsetFromView() {
+  int offsetX{};
+  int offsetY{};
+  int offsetZ{};
+
+  LHOLO_CHECK(lholo::structure::computeRelativeOffsetFromView(
+      0.0f, 1.0f, 0.0f, 120, offsetX, offsetY, offsetZ));
+  LHOLO_CHECK(offsetX == 0);
+  LHOLO_CHECK(offsetY == 1);
+  LHOLO_CHECK(offsetZ == 0);
+
+  offsetX = 0;
+  offsetY = 0;
+  offsetZ = 0;
+  LHOLO_CHECK(lholo::structure::computeRelativeOffsetFromView(
+      0.0f, -1.0f, 0.0f, -120, offsetX, offsetY, offsetZ));
+  LHOLO_CHECK(offsetX == 0);
+  LHOLO_CHECK(offsetY == 1);
+  LHOLO_CHECK(offsetZ == 0);
+
+  offsetX = 0;
+  offsetY = 0;
+  offsetZ = 0;
+  LHOLO_CHECK(lholo::structure::computeRelativeOffsetFromView(
+      1.0f, 0.0f, 0.0f, 120, offsetX, offsetY, offsetZ));
+  LHOLO_CHECK(offsetX == 1);
+  LHOLO_CHECK(offsetY == 0);
+  LHOLO_CHECK(offsetZ == 0);
 }
 
 void testStructureSession() {
-    using lholo::structure::detail::SavedProjectionSnapshot;
-    using lholo::structure::detail::StructureSession;
+  using lholo::structure::detail::SavedProjectionSnapshot;
+  using lholo::structure::detail::StructureSession;
 
-    auto& session = StructureSession::getInstance();
-    session.clearLoaded("尚未加载结构文件");
-    session.resetTransform();
-    session.setLastPath("initial.mcstructure");
-    session.setSavedProjection(SavedProjectionSnapshot{});
+  auto &session = StructureSession::getInstance();
+  session.clearLoaded("尚未加载结构文件");
+  session.resetTransform();
+  session.setLastPath("initial.mcstructure");
+  session.setSavedProjection(SavedProjectionSnapshot{});
 
-    auto snapshot = session.snapshot();
-    LHOLO_CHECK(!snapshot.loaded);
-    LHOLO_CHECK(snapshot.status == "尚未加载结构文件");
-    LHOLO_CHECK(snapshot.lastPath == "initial.mcstructure");
-    LHOLO_CHECK(snapshot.transform.rotation == 0);
-    LHOLO_CHECK(!snapshot.saved.available);
+  auto snapshot = session.snapshot();
+  LHOLO_CHECK(!snapshot.loaded);
+  LHOLO_CHECK(snapshot.status == "尚未加载结构文件");
+  LHOLO_CHECK(snapshot.lastPath == "initial.mcstructure");
+  LHOLO_CHECK(snapshot.transform.rotation == 0);
+  LHOLO_CHECK(!snapshot.saved.available);
 
-    auto loaded = std::make_shared<LoadedStructure>();
-    loaded->sizeX = 7;
-    loaded->sizeY = 5;
-    loaded->sizeZ = 3;
-    session.replaceLoaded(loaded, "active.mcstructure", "loaded");
-    LHOLO_CHECK(session.setRotation(2));
-    LHOLO_CHECK(!session.setRotation(2));
-    LHOLO_CHECK(session.setMirror(1));
-    LHOLO_CHECK(session.setOffsetX(12));
-    LHOLO_CHECK(session.setOffsetY(-4));
-    LHOLO_CHECK(session.setLayerDisplayMode(1));
-    LHOLO_CHECK(session.setDisplayLayer(4));
-    LHOLO_CHECK(session.setLayerAxis(1));
+  auto loaded = std::make_shared<LoadedStructure>();
+  loaded->sizeX = 7;
+  loaded->sizeY = 5;
+  loaded->sizeZ = 3;
+  session.replaceLoaded(loaded, "active.mcstructure", "loaded");
+  LHOLO_CHECK(session.setRotation(2));
+  LHOLO_CHECK(!session.setRotation(2));
+  LHOLO_CHECK(session.setMirror(1));
+  LHOLO_CHECK(session.setOffsetX(12));
+  LHOLO_CHECK(session.setOffsetY(-4));
+  LHOLO_CHECK(session.setLayerDisplayMode(1));
+  LHOLO_CHECK(session.setDisplayLayer(4));
+  LHOLO_CHECK(session.setLayerAxis(1));
 
-    snapshot = session.snapshot();
-    LHOLO_CHECK(snapshot.loaded == loaded);
-    LHOLO_CHECK(snapshot.maxLayerY == 4);
-    LHOLO_CHECK(snapshot.maxLayerX == 6);
-    LHOLO_CHECK(snapshot.transform.offsetX == 12);
-    LHOLO_CHECK(snapshot.transform.offsetY == -4);
+  snapshot = session.snapshot();
+  LHOLO_CHECK(snapshot.loaded == loaded);
+  LHOLO_CHECK(snapshot.maxLayerY == 4);
+  LHOLO_CHECK(snapshot.maxLayerX == 6);
+  LHOLO_CHECK(snapshot.transform.offsetX == 12);
+  LHOLO_CHECK(snapshot.transform.offsetY == -4);
 
-    session.recordProjectionAnchor(10, 20, 30);
-    auto const saved = session.savedProjection();
-    LHOLO_CHECK(saved.available);
-    LHOLO_CHECK(saved.anchorX == 10);
-    LHOLO_CHECK(saved.anchorY == 20);
-    LHOLO_CHECK(saved.anchorZ == 30);
-    LHOLO_CHECK(saved.transform.rotation == 2);
-    LHOLO_CHECK(saved.transform.mirror == 1);
-    LHOLO_CHECK(saved.structurePath == "active.mcstructure");
+  session.recordProjectionAnchor(10, 20, 30);
+  auto const saved = session.savedProjection();
+  LHOLO_CHECK(saved.available);
+  LHOLO_CHECK(saved.anchorX == 10);
+  LHOLO_CHECK(saved.anchorY == 20);
+  LHOLO_CHECK(saved.anchorZ == 30);
+  LHOLO_CHECK(saved.transform.rotation == 2);
+  LHOLO_CHECK(saved.transform.mirror == 1);
+  LHOLO_CHECK(saved.structurePath == "active.mcstructure");
 
-    auto layered = std::make_shared<LoadedStructure>();
-    layered->sizeX = 3;
-    layered->sizeY = 8;
-    layered->sizeZ = 4;
-    session.replaceLoaded(layered, "layered.mcstructure", "layered");
-    session.setLayerDisplayMode(2);
-    session.setDisplayLayer(7);
-    session.setLayerAxis(0);
-    session.recordProjectionAnchor(40, 50, 60);
-    session.clearLoaded("closed");
-    session.setDisplayLayer(0); // Empty-menu clamping must not alter the saved layer.
-    auto const layeredSaved = session.savedProjection();
-    LHOLO_CHECK(layeredSaved.transform.layerDisplayMode == 2);
-    LHOLO_CHECK(layeredSaved.transform.displayLayer == 7);
-    LHOLO_CHECK(layeredSaved.transform.layerAxis == 0);
+  auto layered = std::make_shared<LoadedStructure>();
+  layered->sizeX = 3;
+  layered->sizeY = 8;
+  layered->sizeZ = 4;
+  session.replaceLoaded(layered, "layered.mcstructure", "layered");
+  session.setLayerDisplayMode(2);
+  session.setDisplayLayer(7);
+  session.setLayerAxis(0);
+  session.recordProjectionAnchor(40, 50, 60);
+  session.clearLoaded("closed");
+  session.setDisplayLayer(
+      0); // Empty-menu clamping must not alter the saved layer.
+  auto const layeredSaved = session.savedProjection();
+  LHOLO_CHECK(layeredSaved.transform.layerDisplayMode == 2);
+  LHOLO_CHECK(layeredSaved.transform.displayLayer == 7);
+  LHOLO_CHECK(layeredSaved.transform.layerAxis == 0);
 
-    session.setLayerDisplayMode(layeredSaved.transform.layerDisplayMode);
-    session.setDisplayLayer(layeredSaved.transform.displayLayer);
-    session.setLayerAxis(layeredSaved.transform.layerAxis);
-    session.replaceLoaded(layered, layeredSaved.structurePath, "restored");
-    snapshot = session.snapshot();
-    LHOLO_CHECK(snapshot.loaded == layered);
-    LHOLO_CHECK(snapshot.maxLayerY == 7);
-    LHOLO_CHECK(snapshot.transform.displayLayer == 7);
+  session.setLayerDisplayMode(layeredSaved.transform.layerDisplayMode);
+  session.setDisplayLayer(layeredSaved.transform.displayLayer);
+  session.setLayerAxis(layeredSaved.transform.layerAxis);
+  session.replaceLoaded(layered, layeredSaved.structurePath, "restored");
+  snapshot = session.snapshot();
+  LHOLO_CHECK(snapshot.loaded == layered);
+  LHOLO_CHECK(snapshot.maxLayerY == 7);
+  LHOLO_CHECK(snapshot.transform.displayLayer == 7);
 
-    session.clearLoaded("closed");
+  session.clearLoaded("closed");
 }
 
 void testPlacementState() {
-    using lholo::place::detail::FailedPlanKey;
-    using lholo::place::detail::PlacementState;
+  using lholo::place::detail::FailedPlanKey;
+  using lholo::place::detail::PlacementState;
 
-    auto& state = PlacementState::getInstance();
-    state.setEnabled(true);
-    state.setRangeEnabled(true);
-    state.setManualMode(true);
-    state.setRadius(3);
-    state.setAutoPlacementBreakCooldownSeconds(12);
-    state.setManualPressAt(100);
-    state.setLastManualPlaceAt(80);
-    state.setManualPlaceRequested(true);
-    state.setManualHeld(true);
-    state.setNextPlaceAt(140);
-    state.setNextSwapAt(150);
+  auto &state = PlacementState::getInstance();
+  state.setEnabled(true);
+  state.setRangeEnabled(true);
+  state.setManualMode(true);
+  state.setRadius(3);
+  state.setAutoPlacementBreakCooldownSeconds(12);
+  state.setManualPressAt(100);
+  state.setLastManualPlaceAt(80);
+  state.setManualPlaceRequested(true);
+  state.setManualHeld(true);
+  state.setNextPlaceAt(140);
+  state.setNextSwapAt(150);
 
-    LHOLO_CHECK(state.enabled());
-    LHOLO_CHECK(state.rangeEnabled());
-    LHOLO_CHECK(state.manualMode());
-    LHOLO_CHECK(state.radius() == 3);
-    LHOLO_CHECK(state.autoPlacementBreakCooldownSeconds() == 12);
-    LHOLO_CHECK(state.manualPressAt() == 100);
-    LHOLO_CHECK(state.lastManualPlaceAt() == 80);
-    LHOLO_CHECK(state.manualPlaceRequested());
-    LHOLO_CHECK(state.manualHeld());
-    LHOLO_CHECK(state.nextPlaceAt() == 140);
-    LHOLO_CHECK(state.nextSwapAt() == 150);
+  LHOLO_CHECK(state.enabled());
+  LHOLO_CHECK(state.rangeEnabled());
+  LHOLO_CHECK(state.manualMode());
+  LHOLO_CHECK(state.radius() == 3);
+  LHOLO_CHECK(state.autoPlacementBreakCooldownSeconds() == 12);
+  LHOLO_CHECK(state.manualPressAt() == 100);
+  LHOLO_CHECK(state.lastManualPlaceAt() == 80);
+  LHOLO_CHECK(state.manualPlaceRequested());
+  LHOLO_CHECK(state.manualHeld());
+  LHOLO_CHECK(state.nextPlaceAt() == 140);
+  LHOLO_CHECK(state.nextSwapAt() == 150);
 
-    constexpr std::int64_t recentCell = 0x123456789LL;
-    state.recordRecentPlacement(recentCell, 100, 150);
-    LHOLO_CHECK(state.recentPlacementActive(recentCell, 149));
-    LHOLO_CHECK(!state.recentPlacementActive(recentCell, 150));
+  constexpr std::int64_t recentCell = 0x123456789LL;
+  state.recordRecentPlacement(recentCell, 100, 150);
+  LHOLO_CHECK(state.recentPlacementActive(recentCell, 149));
+  LHOLO_CHECK(!state.recentPlacementActive(recentCell, 150));
 
-    constexpr std::int64_t suppressedCell = 0x23456789ALL;
-    LHOLO_CHECK(!state.autoPlacementSuppressionsActive(100));
-    state.suppressAutoPlacement(suppressedCell, 200);
-    LHOLO_CHECK(state.autoPlacementSuppressionsActive(100));
-    LHOLO_CHECK(state.autoPlacementSuppressed(suppressedCell, 199));
-    LHOLO_CHECK(!state.autoPlacementSuppressionsActive(200));
-    LHOLO_CHECK(!state.autoPlacementSuppressed(suppressedCell, 200));
+  constexpr std::int64_t suppressedCell = 0x23456789ALL;
+  LHOLO_CHECK(!state.autoPlacementSuppressionsActive(100));
+  state.suppressAutoPlacement(suppressedCell, 200);
+  LHOLO_CHECK(state.autoPlacementSuppressionsActive(100));
+  LHOLO_CHECK(state.autoPlacementSuppressed(suppressedCell, 199));
+  LHOLO_CHECK(!state.autoPlacementSuppressionsActive(200));
+  LHOLO_CHECK(!state.autoPlacementSuppressed(suppressedCell, 200));
 
-    // Extending the current earliest entry may leave the cheap expiry hint at
-    // its old value, but the first boundary refresh must retain the live entry.
-    state.suppressAutoPlacement(suppressedCell, 300);
-    state.suppressAutoPlacement(suppressedCell, 350);
-    LHOLO_CHECK(state.autoPlacementSuppressionsActive(300));
-    LHOLO_CHECK(state.autoPlacementSuppressed(suppressedCell, 349));
-    LHOLO_CHECK(!state.autoPlacementSuppressionsActive(350));
+  // Extending the current earliest entry may leave the cheap expiry hint at
+  // its old value, but the first boundary refresh must retain the live entry.
+  state.suppressAutoPlacement(suppressedCell, 300);
+  state.suppressAutoPlacement(suppressedCell, 350);
+  LHOLO_CHECK(state.autoPlacementSuppressionsActive(300));
+  LHOLO_CHECK(state.autoPlacementSuppressed(suppressedCell, 349));
+  LHOLO_CHECK(!state.autoPlacementSuppressionsActive(350));
 
-    FailedPlanKey const failedKey{recentCell, 42, 7, 1, 2, 3, 4, 5, 6};
-    state.cacheFailedPlan(failedKey, 200, 250);
-    LHOLO_CHECK(state.failedPlanCached(failedKey, 249));
-    LHOLO_CHECK(!state.failedPlanCached(failedKey, 250));
+  FailedPlanKey const failedKey{recentCell, 42, 7, 1, 2, 3, 4, 5, 6};
+  state.cacheFailedPlan(failedKey, 200, 250);
+  LHOLO_CHECK(state.failedPlanCached(failedKey, 249));
+  LHOLO_CHECK(!state.failedPlanCached(failedKey, 250));
 
-    state.setAimedProjectedBlockName("Test projected block");
-    LHOLO_CHECK(state.aimedProjectedBlockName() == "Test projected block");
+  state.setAimedProjectedBlockName("Test projected block");
+  LHOLO_CHECK(state.aimedProjectedBlockName() == "Test projected block");
 
-    state.recordRecentPlacement(recentCell, 400, 500);
-    state.suppressAutoPlacement(suppressedCell, 500);
-    state.cacheFailedPlan(failedKey, 400, 500);
-    state.resetDimensionSession();
-    LHOLO_CHECK(state.enabled());
-    LHOLO_CHECK(state.rangeEnabled());
-    LHOLO_CHECK(state.manualMode());
-    LHOLO_CHECK(!state.manualHeld());
-    LHOLO_CHECK(!state.manualPlaceRequested());
-    LHOLO_CHECK(state.manualPressAt() == 0);
-    LHOLO_CHECK(state.lastManualPlaceAt() == 0);
-    LHOLO_CHECK(state.nextPlaceAt() == 0);
-    LHOLO_CHECK(state.nextSwapAt() == 0);
-    LHOLO_CHECK(!state.recentPlacementActive(recentCell, 400));
-    LHOLO_CHECK(!state.autoPlacementSuppressionsActive(400));
-    LHOLO_CHECK(!state.autoPlacementSuppressed(suppressedCell, 400));
-    LHOLO_CHECK(!state.failedPlanCached(failedKey, 400));
-    LHOLO_CHECK(state.aimedProjectedBlockName().empty());
-    LHOLO_CHECK(state.radius() == 3);
-    LHOLO_CHECK(state.autoPlacementBreakCooldownSeconds() == 12);
+  state.recordRecentPlacement(recentCell, 400, 500);
+  state.suppressAutoPlacement(suppressedCell, 500);
+  state.cacheFailedPlan(failedKey, 400, 500);
+  state.resetDimensionSession();
+  LHOLO_CHECK(state.enabled());
+  LHOLO_CHECK(state.rangeEnabled());
+  LHOLO_CHECK(state.manualMode());
+  LHOLO_CHECK(!state.manualHeld());
+  LHOLO_CHECK(!state.manualPlaceRequested());
+  LHOLO_CHECK(state.manualPressAt() == 0);
+  LHOLO_CHECK(state.lastManualPlaceAt() == 0);
+  LHOLO_CHECK(state.nextPlaceAt() == 0);
+  LHOLO_CHECK(state.nextSwapAt() == 0);
+  LHOLO_CHECK(!state.recentPlacementActive(recentCell, 400));
+  LHOLO_CHECK(!state.autoPlacementSuppressionsActive(400));
+  LHOLO_CHECK(!state.autoPlacementSuppressed(suppressedCell, 400));
+  LHOLO_CHECK(!state.failedPlanCached(failedKey, 400));
+  LHOLO_CHECK(state.aimedProjectedBlockName().empty());
+  LHOLO_CHECK(state.radius() == 3);
+  LHOLO_CHECK(state.autoPlacementBreakCooldownSeconds() == 12);
 
-    state.setManualHeld(true);
-    state.setManualPlaceRequested(true);
-    state.setAimedProjectedBlockName("World projected block");
-    state.suppressAutoPlacement(suppressedCell, 500);
-    state.resetWorldSession();
-    LHOLO_CHECK(!state.enabled());
-    LHOLO_CHECK(!state.rangeEnabled());
-    LHOLO_CHECK(!state.manualMode());
-    LHOLO_CHECK(!state.manualHeld());
-    LHOLO_CHECK(!state.manualPlaceRequested());
-    LHOLO_CHECK(state.manualPressAt() == 0);
-    LHOLO_CHECK(state.lastManualPlaceAt() == 0);
-    LHOLO_CHECK(state.nextPlaceAt() == 0);
-    LHOLO_CHECK(state.nextSwapAt() == 0);
-    LHOLO_CHECK(!state.recentPlacementActive(recentCell, 0));
-    LHOLO_CHECK(!state.autoPlacementSuppressionsActive(0));
-    LHOLO_CHECK(!state.autoPlacementSuppressed(suppressedCell, 0));
-    LHOLO_CHECK(!state.failedPlanCached(failedKey, 0));
-    LHOLO_CHECK(state.aimedProjectedBlockName().empty());
-    // User configuration survives a world transition.
-    LHOLO_CHECK(state.radius() == 3);
-    LHOLO_CHECK(state.autoPlacementBreakCooldownSeconds() == 12);
+  state.setManualHeld(true);
+  state.setManualPlaceRequested(true);
+  state.setAimedProjectedBlockName("World projected block");
+  state.suppressAutoPlacement(suppressedCell, 500);
+  state.resetWorldSession();
+  LHOLO_CHECK(!state.enabled());
+  LHOLO_CHECK(!state.rangeEnabled());
+  LHOLO_CHECK(!state.manualMode());
+  LHOLO_CHECK(!state.manualHeld());
+  LHOLO_CHECK(!state.manualPlaceRequested());
+  LHOLO_CHECK(state.manualPressAt() == 0);
+  LHOLO_CHECK(state.lastManualPlaceAt() == 0);
+  LHOLO_CHECK(state.nextPlaceAt() == 0);
+  LHOLO_CHECK(state.nextSwapAt() == 0);
+  LHOLO_CHECK(!state.recentPlacementActive(recentCell, 0));
+  LHOLO_CHECK(!state.autoPlacementSuppressionsActive(0));
+  LHOLO_CHECK(!state.autoPlacementSuppressed(suppressedCell, 0));
+  LHOLO_CHECK(!state.failedPlanCached(failedKey, 0));
+  LHOLO_CHECK(state.aimedProjectedBlockName().empty());
+  // User configuration survives a world transition.
+  LHOLO_CHECK(state.radius() == 3);
+  LHOLO_CHECK(state.autoPlacementBreakCooldownSeconds() == 12);
 
-    state.setRadius(4);
-    state.setAutoPlacementBreakCooldownSeconds(10);
+  state.setRadius(4);
+  state.setAutoPlacementBreakCooldownSeconds(10);
 }
 
 void testStructureUiState() {
-    using lholo::structure::detail::HudStateSnapshot;
-    using lholo::structure::detail::StructureUiState;
+  using lholo::structure::detail::HudStateSnapshot;
+  using lholo::structure::detail::StructureUiState;
 
-    auto& state = StructureUiState::getInstance();
-    state.resetHotkeys();
-    state.resetHotkeyState();
-    state.stopHotkeyCapture();
-    (void)state.consumePendingHotkeyActions();
-    state.clearMaterials();
+  auto &state = StructureUiState::getInstance();
+  state.resetHotkeys();
+  state.resetHotkeyState();
+  state.stopHotkeyCapture();
+  (void)state.consumePendingHotkeyActions();
+  state.clearMaterials();
 
-    auto hud = state.hud();
-    hud.enabled = false;
-    hud.showLayer = false;
-    hud.showProjectedBlockName = false;
-    hud.position = 3;
-    hud.uiScale = 1.5f;
-    LHOLO_CHECK(state.applyHud(hud));
-    LHOLO_CHECK(!state.applyHud(hud));
-    auto const appliedHud = state.hud();
-    LHOLO_CHECK(!appliedHud.enabled);
-    LHOLO_CHECK(!appliedHud.showLayer);
-    LHOLO_CHECK(!appliedHud.showProjectedBlockName);
-    LHOLO_CHECK(appliedHud.position == 3);
-    LHOLO_CHECK(appliedHud.uiScale == 1.5f);
+  auto hud = state.hud();
+  hud.enabled = false;
+  hud.showLayer = false;
+  hud.showProjectedBlockName = false;
+  hud.position = 3;
+  hud.uiScale = 1.5f;
+  LHOLO_CHECK(state.applyHud(hud));
+  LHOLO_CHECK(!state.applyHud(hud));
+  auto const appliedHud = state.hud();
+  LHOLO_CHECK(!appliedHud.enabled);
+  LHOLO_CHECK(!appliedHud.showLayer);
+  LHOLO_CHECK(!appliedHud.showProjectedBlockName);
+  LHOLO_CHECK(appliedHud.position == 3);
+  LHOLO_CHECK(appliedHud.uiScale == 1.5f);
 
-    state.resetHotkeys();
-    auto const guiSlot = lholo::input::hotkeyIndex(lholo::input::HotkeyId::Gui);
-    auto const moveXMinusSlot = lholo::input::hotkeyIndex(lholo::input::HotkeyId::MoveXMinus);
-    auto const moveXPlusSlot = lholo::input::hotkeyIndex(lholo::input::HotkeyId::MoveXPlus);
-    auto const layerIncreaseSlot = lholo::input::hotkeyIndex(lholo::input::HotkeyId::LayerIncrease);
-    auto const loadProjectionSlot = lholo::input::hotkeyIndex(lholo::input::HotkeyId::LoadProjection);
-    auto const closeProjectionSlot = lholo::input::hotkeyIndex(lholo::input::HotkeyId::CloseProjection);
-    LHOLO_CHECK(state.hotkey(guiSlot).key == 'M');
-    LHOLO_CHECK(state.hotkey(guiSlot).modifiers == lholo::ui::kHotkeyModifierAlt);
-    LHOLO_CHECK(state.hotkey(moveXMinusSlot).key == VK_LEFT);
-    LHOLO_CHECK(state.hotkey(layerIncreaseSlot).key == VK_UP);
-    LHOLO_CHECK(state.hotkey(loadProjectionSlot).key == 0);
-    LHOLO_CHECK(state.hotkey(closeProjectionSlot).key == 0);
+  state.resetHotkeys();
+  auto const guiSlot = lholo::input::hotkeyIndex(lholo::input::HotkeyId::Gui);
+  auto const moveXMinusSlot =
+      lholo::input::hotkeyIndex(lholo::input::HotkeyId::MoveXMinus);
+  auto const moveXPlusSlot =
+      lholo::input::hotkeyIndex(lholo::input::HotkeyId::MoveXPlus);
+  auto const layerIncreaseSlot =
+      lholo::input::hotkeyIndex(lholo::input::HotkeyId::LayerIncrease);
+  auto const loadProjectionSlot =
+      lholo::input::hotkeyIndex(lholo::input::HotkeyId::LoadProjection);
+  auto const closeProjectionSlot =
+      lholo::input::hotkeyIndex(lholo::input::HotkeyId::CloseProjection);
+  LHOLO_CHECK(state.hotkey(guiSlot).key == 'M');
+  LHOLO_CHECK(state.hotkey(guiSlot).modifiers == lholo::ui::kHotkeyModifierAlt);
+  LHOLO_CHECK(state.hotkey(moveXMinusSlot).key == VK_LEFT);
+  LHOLO_CHECK(state.hotkey(layerIncreaseSlot).key == VK_UP);
+  LHOLO_CHECK(state.hotkey(loadProjectionSlot).key == 0);
+  LHOLO_CHECK(state.hotkey(closeProjectionSlot).key == 0);
 
-    state.beginHotkeyCapture(moveXMinusSlot);
-    LHOLO_CHECK(state.capturingHotkey() == moveXMinusSlot);
-    state.setHotkey(moveXPlusSlot, 'K', lholo::ui::kHotkeyModifierControl);
-    state.bindCapturedHotkey(moveXMinusSlot, 'K', lholo::ui::kHotkeyModifierControl);
-    LHOLO_CHECK(state.hotkey(moveXMinusSlot).key == 'K');
-    LHOLO_CHECK(state.hotkey(moveXPlusSlot).key == 0);
-    LHOLO_CHECK(!state.capturingHotkey());
+  state.beginHotkeyCapture(moveXMinusSlot);
+  LHOLO_CHECK(state.capturingHotkey() == moveXMinusSlot);
+  state.setHotkey(moveXPlusSlot, 'K', lholo::ui::kHotkeyModifierControl);
+  state.bindCapturedHotkey(moveXMinusSlot, 'K',
+                           lholo::ui::kHotkeyModifierControl);
+  LHOLO_CHECK(state.hotkey(moveXMinusSlot).key == 'K');
+  LHOLO_CHECK(state.hotkey(moveXPlusSlot).key == 0);
+  LHOLO_CHECK(!state.capturingHotkey());
 
-    state.setControlHeld(true);
-    state.setShiftHeld(true);
-    LHOLO_CHECK(
-        state.currentHotkeyModifiers()
-        == (lholo::ui::kHotkeyModifierControl | lholo::ui::kHotkeyModifierShift)
-    );
-    state.setControlHeld(false);
-    state.setShiftHeld(false);
+  state.setControlHeld(true);
+  state.setShiftHeld(true);
+  LHOLO_CHECK(
+      state.currentHotkeyModifiers() ==
+      (lholo::ui::kHotkeyModifierControl | lholo::ui::kHotkeyModifierShift));
+  state.setControlHeld(false);
+  state.setShiftHeld(false);
 
-    state.resetHotkeys();
-    LHOLO_CHECK(state.tryPressHotkey(guiSlot));
-    LHOLO_CHECK(!state.tryPressHotkey(guiSlot));
-    LHOLO_CHECK(state.releaseHotkeysForKey('M', 100));
-    LHOLO_CHECK(state.releaseHotkeysForKey('M', 150));
-    LHOLO_CHECK(!state.releaseHotkeysForKey('M', 201));
+  state.resetHotkeys();
+  LHOLO_CHECK(state.tryPressHotkey(guiSlot));
+  LHOLO_CHECK(!state.tryPressHotkey(guiSlot));
+  LHOLO_CHECK(state.releaseHotkeysForKey('M', 100));
+  LHOLO_CHECK(state.releaseHotkeysForKey('M', 150));
+  LHOLO_CHECK(!state.releaseHotkeysForKey('M', 201));
 
-    state.queueMove(0);
-    state.queueMove(4);
-    state.queueLayerDelta(-1);
-    state.queueLoadProjection();
-    state.queueCloseProjection();
-    state.requestSettingsSave();
-    auto const pending = state.consumePendingHotkeyActions();
-    LHOLO_CHECK(pending.offsetX == -1);
-    LHOLO_CHECK(pending.offsetY == 1);
-    LHOLO_CHECK(pending.offsetZ == 0);
-    LHOLO_CHECK(pending.layerDelta == -1);
-    LHOLO_CHECK(pending.loadProjection);
-    LHOLO_CHECK(pending.closeProjection);
-    LHOLO_CHECK(pending.settingsSave);
+  state.queueMove(0);
+  state.queueMove(4);
+  state.queueLayerDelta(-1);
+  state.queueLoadProjection();
+  state.queueCloseProjection();
+  state.requestSettingsSave();
+  auto const pending = state.consumePendingHotkeyActions();
+  LHOLO_CHECK(pending.offsetX == -1);
+  LHOLO_CHECK(pending.offsetY == 1);
+  LHOLO_CHECK(pending.offsetZ == 0);
+  LHOLO_CHECK(pending.layerDelta == -1);
+  LHOLO_CHECK(pending.loadProjection);
+  LHOLO_CHECK(pending.closeProjection);
+  LHOLO_CHECK(pending.settingsSave);
 
-    state.clearMaterials();
-    LHOLO_CHECK(!state.materialListReady());
-    state.requestMaterialList();
-    LHOLO_CHECK(state.consumeMaterialListRequest());
-    LHOLO_CHECK(!state.consumeMaterialListRequest());
-    state.replaceMaterialRequirements({{"Stone", "minecraft:stone", "minecraft:stone", 12}});
-    LHOLO_CHECK(state.materialListReady());
-    // Reopening a completed list must not queue another full structure scan.
-    state.requestMaterialList();
-    LHOLO_CHECK(!state.consumeMaterialListRequest());
-    auto const materials = state.materialRequirements();
-    LHOLO_CHECK(materials.size() == 1);
-    LHOLO_CHECK(materials[0].typeName == "minecraft:stone");
-    LHOLO_CHECK(materials[0].itemId == "minecraft:stone");
-    LHOLO_CHECK(materials[0].count == 12);
+  state.clearMaterials();
+  LHOLO_CHECK(!state.materialListReady());
+  state.requestMaterialList();
+  LHOLO_CHECK(state.consumeMaterialListRequest());
+  LHOLO_CHECK(!state.consumeMaterialListRequest());
+  state.replaceMaterialRequirements(
+      {{"Stone", "minecraft:stone", "minecraft:stone", 12}});
+  LHOLO_CHECK(state.materialListReady());
+  // Reopening a completed list must not queue another full structure scan.
+  state.requestMaterialList();
+  LHOLO_CHECK(!state.consumeMaterialListRequest());
+  auto const materials = state.materialRequirements();
+  LHOLO_CHECK(materials.size() == 1);
+  LHOLO_CHECK(materials[0].typeName == "minecraft:stone");
+  LHOLO_CHECK(materials[0].itemId == "minecraft:stone");
+  LHOLO_CHECK(materials[0].count == 12);
 
-    auto hudMaterials = state.materialHudSnapshot();
-    LHOLO_CHECK(!hudMaterials.ready);
-    state.replaceMaterialHudSnapshot(
-        {{"Glass", "minecraft:glass", "minecraft:glass", 5}},
-        {2}
-    );
-    hudMaterials = state.materialHudSnapshot();
-    LHOLO_CHECK(hudMaterials.ready);
-    LHOLO_CHECK(hudMaterials.requirements.size() == 1);
-    LHOLO_CHECK(hudMaterials.requirements[0].count == 5);
-    LHOLO_CHECK(hudMaterials.available.size() == 1);
-    LHOLO_CHECK(hudMaterials.available[0] == 2);
-    // Updating the current-layer HUD must not replace the whole-structure list.
-    LHOLO_CHECK(state.materialRequirements()[0].typeName == "minecraft:stone");
-    state.clearMaterialHud();
-    LHOLO_CHECK(!state.materialHudSnapshot().ready);
+  auto hudMaterials = state.materialHudSnapshot();
+  LHOLO_CHECK(!hudMaterials.ready);
+  state.replaceMaterialHudSnapshot(
+      {{"Glass", "minecraft:glass", "minecraft:glass", 5}}, {2});
+  hudMaterials = state.materialHudSnapshot();
+  LHOLO_CHECK(hudMaterials.ready);
+  LHOLO_CHECK(hudMaterials.requirements.size() == 1);
+  LHOLO_CHECK(hudMaterials.requirements[0].count == 5);
+  LHOLO_CHECK(hudMaterials.available.size() == 1);
+  LHOLO_CHECK(hudMaterials.available[0] == 2);
+  // Updating the current-layer HUD must not replace the whole-structure list.
+  LHOLO_CHECK(state.materialRequirements()[0].typeName == "minecraft:stone");
+  state.clearMaterialHud();
+  LHOLO_CHECK(!state.materialHudSnapshot().ready);
 
-    state.setExperimentalConsentGiven(true);
-    state.setMaterialHudEnabled(true);
-    state.setMaterialHudPosition(3);
-    state.setActionHint("test", 1234);
-    LHOLO_CHECK(state.experimentalConsentGiven());
-    LHOLO_CHECK(state.materialHudEnabled());
-    LHOLO_CHECK(state.materialHudPosition() == 3);
-    auto const hint = state.actionHint();
-    LHOLO_CHECK(hint.text == "test");
-    LHOLO_CHECK(hint.expiry == 1234);
+  state.setExperimentalConsentGiven(true);
+  state.setMaterialHudEnabled(true);
+  state.setMaterialHudPosition(3);
+  state.setActionHint("test", 1234);
+  LHOLO_CHECK(state.experimentalConsentGiven());
+  LHOLO_CHECK(state.materialHudEnabled());
+  LHOLO_CHECK(state.materialHudPosition() == 3);
+  auto const hint = state.actionHint();
+  LHOLO_CHECK(hint.text == "test");
+  LHOLO_CHECK(hint.expiry == 1234);
 
-    state.setGuiVisible(false);
-    LHOLO_CHECK(state.toggleGuiVisible());
-    LHOLO_CHECK(state.guiVisible());
-    state.setOpeningInputBlockFrames(1);
-    LHOLO_CHECK(state.openingInputBlocked());
-    state.consumeOpeningInputBlockFrame();
-    LHOLO_CHECK(!state.openingInputBlocked());
+  state.setGuiVisible(false);
+  LHOLO_CHECK(state.toggleGuiVisible());
+  LHOLO_CHECK(state.guiVisible());
+  state.setOpeningInputBlockFrames(1);
+  LHOLO_CHECK(state.openingInputBlocked());
+  state.consumeOpeningInputBlockFrame();
+  LHOLO_CHECK(!state.openingInputBlocked());
 
-    state.setGuiVisible(true);
-    state.setOpeningInputBlockFrames(3);
-    state.setBlockGameInputUntil(900);
-    state.beginHotkeyCapture(moveXMinusSlot);
-    state.setControlHeld(true);
-    state.queueMove(1);
-    state.queueLayerDelta(1);
-    state.queueLoadProjection();
-    state.queueCloseProjection();
-    state.requestSettingsSave();
-    state.replaceMaterialRequirements({{"Stone", "minecraft:stone", "minecraft:stone", 4}});
-    state.replaceMaterialHudSnapshot(
-        {{"Glass", "minecraft:glass", "minecraft:glass", 2}},
-        {1}
-    );
-    state.setActionHint("world hint", 9999);
-    state.resetWorldSession();
-    LHOLO_CHECK(!state.guiVisible());
-    LHOLO_CHECK(!state.openingInputBlocked());
-    LHOLO_CHECK(state.blockGameInputUntil() == 0);
-    LHOLO_CHECK(!state.capturingHotkey());
-    LHOLO_CHECK(state.currentHotkeyModifiers() == 0);
-    LHOLO_CHECK(!state.materialListReady());
-    LHOLO_CHECK(!state.materialHudSnapshot().ready);
-    LHOLO_CHECK(state.actionHint().text.empty());
-    LHOLO_CHECK(state.actionHint().expiry == 0);
-    auto const afterWorldExit = state.consumePendingHotkeyActions();
-    LHOLO_CHECK(afterWorldExit.offsetX == 0);
-    LHOLO_CHECK(afterWorldExit.offsetY == 0);
-    LHOLO_CHECK(afterWorldExit.offsetZ == 0);
-    LHOLO_CHECK(afterWorldExit.layerDelta == 0);
-    LHOLO_CHECK(!afterWorldExit.loadProjection);
-    LHOLO_CHECK(!afterWorldExit.closeProjection);
-    // A pending settings write is not world-owned and must still complete.
-    LHOLO_CHECK(afterWorldExit.settingsSave);
-    LHOLO_CHECK(state.experimentalConsentGiven());
-    LHOLO_CHECK(state.materialHudEnabled());
-    LHOLO_CHECK(state.materialHudPosition() == 3);
+  state.setGuiVisible(true);
+  state.setOpeningInputBlockFrames(3);
+  state.setBlockGameInputUntil(900);
+  state.beginHotkeyCapture(moveXMinusSlot);
+  state.setControlHeld(true);
+  state.queueMove(1);
+  state.queueLayerDelta(1);
+  state.queueLoadProjection();
+  state.queueCloseProjection();
+  state.requestSettingsSave();
+  state.replaceMaterialRequirements(
+      {{"Stone", "minecraft:stone", "minecraft:stone", 4}});
+  state.replaceMaterialHudSnapshot(
+      {{"Glass", "minecraft:glass", "minecraft:glass", 2}}, {1});
+  state.setActionHint("world hint", 9999);
+  state.resetWorldSession();
+  LHOLO_CHECK(!state.guiVisible());
+  LHOLO_CHECK(!state.openingInputBlocked());
+  LHOLO_CHECK(state.blockGameInputUntil() == 0);
+  LHOLO_CHECK(!state.capturingHotkey());
+  LHOLO_CHECK(state.currentHotkeyModifiers() == 0);
+  LHOLO_CHECK(!state.materialListReady());
+  LHOLO_CHECK(!state.materialHudSnapshot().ready);
+  LHOLO_CHECK(state.actionHint().text.empty());
+  LHOLO_CHECK(state.actionHint().expiry == 0);
+  auto const afterWorldExit = state.consumePendingHotkeyActions();
+  LHOLO_CHECK(afterWorldExit.offsetX == 0);
+  LHOLO_CHECK(afterWorldExit.offsetY == 0);
+  LHOLO_CHECK(afterWorldExit.offsetZ == 0);
+  LHOLO_CHECK(afterWorldExit.layerDelta == 0);
+  LHOLO_CHECK(!afterWorldExit.loadProjection);
+  LHOLO_CHECK(!afterWorldExit.closeProjection);
+  // A pending settings write is not world-owned and must still complete.
+  LHOLO_CHECK(afterWorldExit.settingsSave);
+  LHOLO_CHECK(state.experimentalConsentGiven());
+  LHOLO_CHECK(state.materialHudEnabled());
+  LHOLO_CHECK(state.materialHudPosition() == 3);
 
-    state.setGuiVisible(false);
-    state.resetHotkeys();
-    state.resetHotkeyState();
-    state.clearMaterials();
-    LHOLO_CHECK(!state.materialListReady());
-    state.setExperimentalConsentGiven(false);
-    state.setMaterialHudEnabled(false);
-    state.setMaterialHudPosition(3);
-    state.setActionHint({}, 0);
-    state.applyHud(HudStateSnapshot{});
+  state.setGuiVisible(false);
+  state.resetHotkeys();
+  state.resetHotkeyState();
+  state.clearMaterials();
+  LHOLO_CHECK(!state.materialListReady());
+  state.setExperimentalConsentGiven(false);
+  state.setMaterialHudEnabled(false);
+  state.setMaterialHudPosition(3);
+  state.setActionHint({}, 0);
+  state.applyHud(HudStateSnapshot{});
 }
 
 void testHotkeyFormat() {
-    LHOLO_CHECK(lholo::ui::isModifierKey(VK_CONTROL));
-    LHOLO_CHECK(lholo::ui::isModifierKey(VK_MENU));
-    LHOLO_CHECK(lholo::ui::isModifierKey(VK_LWIN));
-    LHOLO_CHECK(!lholo::ui::isModifierKey('A'));
-    LHOLO_CHECK(lholo::ui::hotkeyName(0) == "未设置");
-    LHOLO_CHECK(lholo::ui::hotkeyName(VK_MBUTTON) == "鼠标中键");
-    LHOLO_CHECK(lholo::ui::hotkeyName(VK_XBUTTON1) == "鼠标侧键1");
-    LHOLO_CHECK(lholo::ui::hotkeyName(VK_XBUTTON2) == "鼠标侧键2");
-    LHOLO_CHECK(lholo::ui::hotkeyChordName(0, 0) == "未设置");
-    auto const chord = lholo::ui::hotkeyChordName(lholo::ui::kHotkeyModifierControl, 'M');
-    LHOLO_CHECK(chord.rfind("Ctrl + ", 0) == 0);
-    LHOLO_CHECK(chord.size() > 7);
+  LHOLO_CHECK(lholo::ui::isModifierKey(VK_CONTROL));
+  LHOLO_CHECK(lholo::ui::isModifierKey(VK_MENU));
+  LHOLO_CHECK(lholo::ui::isModifierKey(VK_LWIN));
+  LHOLO_CHECK(!lholo::ui::isModifierKey('A'));
+  LHOLO_CHECK(lholo::ui::hotkeyName(0) == "未设置");
+  LHOLO_CHECK(lholo::ui::hotkeyName(VK_MBUTTON) == "鼠标中键");
+  LHOLO_CHECK(lholo::ui::hotkeyName(VK_XBUTTON1) == "鼠标侧键1");
+  LHOLO_CHECK(lholo::ui::hotkeyName(VK_XBUTTON2) == "鼠标侧键2");
+  LHOLO_CHECK(lholo::ui::hotkeyChordName(0, 0) == "未设置");
+  auto const chord =
+      lholo::ui::hotkeyChordName(lholo::ui::kHotkeyModifierControl, 'M');
+  LHOLO_CHECK(chord.rfind("Ctrl + ", 0) == 0);
+  LHOLO_CHECK(chord.size() > 7);
 }
 
 void testBlockPlacementRules() {
-    using lholo::block::placeableBaseName;
-    LHOLO_CHECK(placeableBaseName("minecraft:lit_redstone_lamp") == "minecraft:redstone_lamp");
-    LHOLO_CHECK(placeableBaseName("minecraft:powered_repeater") == "minecraft:unpowered_repeater");
-    LHOLO_CHECK(placeableBaseName("minecraft:stone") == "minecraft:stone");
+  using lholo::block::placeableBaseName;
+  LHOLO_CHECK(placeableBaseName("minecraft:lit_redstone_lamp") ==
+              "minecraft:redstone_lamp");
+  LHOLO_CHECK(placeableBaseName("minecraft:powered_repeater") ==
+              "minecraft:unpowered_repeater");
+  LHOLO_CHECK(placeableBaseName("minecraft:stone") == "minecraft:stone");
 }
 
 void testJavaTextComponents() {
-    using lholo::structure::detail::javaTextComponentToPlainText;
-    LHOLO_CHECK(javaTextComponentToPlainText(R"("Launch")") == "Launch");
-    LHOLO_CHECK(javaTextComponentToPlainText(R"({"text":"X","extra":[{"text":" count"}]})") == "X count");
-    LHOLO_CHECK(javaTextComponentToPlainText(R"(["A",{"text":"B"}])") == "AB");
-    LHOLO_CHECK(javaTextComponentToPlainText(R"({"translate":"block.minecraft.oak_sign"})")
-                == "block.minecraft.oak_sign");
-    LHOLO_CHECK(javaTextComponentToPlainText("not json") == "not json");
+  using lholo::structure::detail::javaTextComponentToPlainText;
+  LHOLO_CHECK(javaTextComponentToPlainText(R"("Launch")") == "Launch");
+  LHOLO_CHECK(javaTextComponentToPlainText(
+                  R"({"text":"X","extra":[{"text":" count"}]})") == "X count");
+  LHOLO_CHECK(javaTextComponentToPlainText(R"(["A",{"text":"B"}])") == "AB");
+  LHOLO_CHECK(javaTextComponentToPlainText(
+                  R"({"translate":"block.minecraft.oak_sign"})") ==
+              "block.minecraft.oak_sign");
+  LHOLO_CHECK(javaTextComponentToPlainText("not json") == "not json");
 }
 
 } // namespace
 
 int main() {
-    testLayoutRules();
-    testProgress();
-    testSettingsStore();
-    testStructureSession();
-    testPlacementState();
-    testStructureUiState();
-    testHotkeyFormat();
-    testBlockPlacementRules();
-    testJavaTextComponents();
-    std::printf("LHoloLogicTests: %d checks, %d failures\n", gChecks, gFailures);
-    return gFailures == 0 ? 0 : 1;
+  testLayoutRules();
+  testProgress();
+  testSettingsStore();
+  testWheelOffsetFromView();
+  testStructureSession();
+  testPlacementState();
+  testStructureUiState();
+  testHotkeyFormat();
+  testBlockPlacementRules();
+  testJavaTextComponents();
+  std::printf("LHoloLogicTests: %d checks, %d failures\n", gChecks, gFailures);
+  return gFailures == 0 ? 0 : 1;
 }


### PR DESCRIPTION
“快捷结构偏移”：按住快捷键（默认ALT）使用鼠标滚轮向玩家视角方向调整偏移，“快捷结构偏移”属临时名称，请老大思考。
“偏移预览”：在使用快捷键调整偏移时先使用一个预览框预览偏移位置，停止偏移动作一秒后实际执行偏移设置。提升调整偏移的性能。
代码都由ai生成  未深度审查，但简单测试可用，劳烦老大审查