### PR TITLE
feat: stick/scroll projection nudging, placement-mode HUD, and fixes

### DIFF
--- a/src/input/HotkeyTypes.h
+++ b/src/input/HotkeyTypes.h
@@ -21,6 +21,10 @@ enum class HotkeyId : std::uint8_t {
     LayerDecrease,
     LoadProjection,
     CloseProjection,
+    // Held (not pressed) while scrolling to move the projection along the axis
+    // the player faces. Default is Alt. Polled via scrollModifierHeld(), never
+    // dispatched as a press action, so a key of 0 simply means "unbound".
+    ScrollMove,
     Count
 };
 

--- a/src/overlay/ImGuiOverlay.cpp
+++ b/src/overlay/ImGuiOverlay.cpp
@@ -460,6 +460,18 @@ LRESULT CALLBACK windowProc(HWND window, UINT message, WPARAM wParam, LPARAM lPa
             }
         }
     }
+    // TEMP wheel-path diagnostic: is the wheel a classic message here at all?
+    // Alt + wheel nudges the projection along the axis the player is facing
+    // (JE-style). Only during gameplay. Bedrock reads the wheel through its own
+    // input pipeline (not this WndProc), so we can't stop the hotbar here; the
+    // tick thread pins the hotbar slot instead. We just queue the move — the tick
+    // thread reads the player's look vector and applies it.
+    if (!gShuttingDown.load(std::memory_order_acquire) && gImGuiInitialized
+        && !structure::isGuiVisible() && message == WM_MOUSEWHEEL
+        && structure::scrollModifierHeld()) {
+        int const notches = GET_WHEEL_DELTA_WPARAM(wParam) / WHEEL_DELTA;
+        if (notches != 0 && structure::queueFacingScroll(notches)) return 1;
+    }
     if (!gShuttingDown.load(std::memory_order_acquire) && gImGuiInitialized && structure::isGuiVisible()) {
         gMouseHandoffActive.store(false, std::memory_order_release);
         ClipCursor(nullptr);

--- a/src/place/PlaceHelper.cpp
+++ b/src/place/PlaceHelper.cpp
@@ -30,8 +30,10 @@
 #include "mc/client/game/ClientInstance.h"
 #include "mc/client/game/IClientInstance.h"
 #include "mc/client/player/LocalPlayer.h"
+#include "mc/world/ContainerID.h"
 #include "mc/world/gamemode/GameMode.h"
 #include "mc/world/actor/player/Player.h"
+#include "mc/world/actor/player/PlayerInventory.h"
 #include "mc/world/item/ItemStack.h"
 #include "mc/world/level/BlockPos.h"
 #include "mc/world/level/BlockSource.h"
@@ -64,6 +66,33 @@ LL_TYPE_INSTANCE_HOOK(
     structure::detail::tickMaterialTracker(*this);
     detail::tickEasyPlace();
     origin(currentTick);
+}
+
+// Alt + wheel repurposes the mouse wheel to move the projection (JE-style)
+// instead of switching the hotbar. Bedrock changes the hotbar slot through its
+// own input pipeline, not our WndProc, so we suppress the change here at its
+// source: PlayerInventory::selectSlot. Gated tightly — only the local player's
+// inventory, only while Alt is held with a projection loaded, and never for the
+// mod's own placement slot swaps (guarded by ModSlotSelectGuard).
+LL_TYPE_INSTANCE_HOOK(
+    PlayerInventorySelectSlotHook,
+    ll::memory::HookPriority::Normal,
+    PlayerInventory,
+    &PlayerInventory::selectSlot,
+    bool,
+    int          slot,
+    ::ContainerID containerId
+) {
+    if (!detail::modSlotSelectActive()
+        && structure::scrollModifierHeld()
+        && structure::scrollLockActive()) {
+        auto client = ll::service::getClientInstance();
+        auto* localPlayer = client ? client->getLocalPlayer() : nullptr;
+        if (localPlayer && this == &localPlayer->getSupplies()) {
+            return false;  // keep the held item; the wheel is driving the projection
+        }
+    }
+    return origin(slot, containerId);
 }
 
 // Returns true when manual mode is on and `gm` belongs to the local player, i.e.
@@ -143,10 +172,14 @@ LL_TYPE_INSTANCE_HOOK(
             return origin(item);
         }
         placementState().setManualPressAt(GetTickCount64());
-        placementState().setManualHeld(false);
         if (targetStatus == detail::ManualTargetStatus::Ready) {
+            // Mark the button held so holding right-click over a floating
+            // projection keeps placing (the tick's typematic repeat). The tick
+            // clears the hold when the right button is actually released.
+            placementState().setManualHeld(true);
             placementState().setManualPlaceRequested(true);
         } else {
+            placementState().setManualHeld(false);
             placementState().setManualPlaceRequested(false);
             structure::showActionHint("背包中没有对应的投影方块");
         }
@@ -279,10 +312,14 @@ bool installHook() {
     if (GameModeBuildBlockHook::hook() < 0) {
         logger().warn("Failed to install manual-place build hook; manual mode may double-place");
     }
+    if (PlayerInventorySelectSlotHook::hook() < 0) {
+        logger().warn("Failed to install selectSlot hook; Alt+wheel may still scroll the hotbar");
+    }
     return true;
 }
 
 void uninstallHook() {
+    PlayerInventorySelectSlotHook::unhook();
     GameModeBuildBlockHook::unhook();
     GameModeStopBuildHook::unhook();
     GameModeUseItemHook::unhook();

--- a/src/place/PlacementExecutor.cpp
+++ b/src/place/PlacementExecutor.cpp
@@ -70,6 +70,16 @@
 #include <string_view>
 
 namespace lholo::place {
+
+namespace detail {
+namespace {
+thread_local bool tModSlotSelect = false;
+}
+bool modSlotSelectActive() { return tModSlotSelect; }
+ModSlotSelectGuard::ModSlotSelectGuard() : mPrev(tModSlotSelect) { tModSlotSelect = true; }
+ModSlotSelectGuard::~ModSlotSelectGuard() { tModSlotSelect = mPrev; }
+} // namespace detail
+
 namespace {
 
 using detail::FailedPlanKey;
@@ -768,7 +778,7 @@ void tickRangePlaceImpl(LocalPlayer& player, PlacementContext const& placementCo
             placementState().setNextSwapAt(now + kSwapRetryMs);
             return;
         }
-        player.setSelectedSlot(found.slot);
+        { detail::ModSlotSelectGuard g; player.setSelectedSlot(found.slot); }
         if (placeBlock(player, target, found.slot, *found.item)) markPlaced(cell, now);
         return;
     }
@@ -792,6 +802,15 @@ void tickEasyPlaceImpl() {
     if (!client->isInGameInputEnabled() || structure::isGuiVisible()) {
         updateAimedProjectedBlockName(nullptr);
         return;
+    }
+
+    // Refresh the held-stick flag for the stick-tool mode (HUD gating + move).
+    structure::setHoldingStick(player->getSelectedItem().getTypeName() == "minecraft:stick");
+    // Alt + wheel nudges the projection along the axis the player faces. Applied
+    // here (with the player's look vector) independent of any placement mode.
+    {
+        auto const facing = player->getViewVector(1.0f);
+        structure::applyFacingScroll(facing.x, facing.y, facing.z);
     }
 
     bool const placementActive = placementState().enabled()
@@ -836,6 +855,11 @@ void tickEasyPlaceImpl() {
     bool const manualPlacement = placementState().manualMode();
     if (manualPlacement) {
         auto const nowManual = GetTickCount64();
+        // Reliable release detection: the game's stop hook can be missed for the
+        // air/useItem (floating projection) path, so clear the hold whenever the
+        // right button is physically up. This gates the typematic repeat below.
+        bool const rightHeld = (GetAsyncKeyState(VK_RBUTTON) & 0x8000) != 0;
+        if (!rightHeld) placementState().setManualHeld(false);
         bool allowed = false;
         // First block of a press: place it even if the button was already
         // released (a quick tap), until the request goes stale.
@@ -847,8 +871,9 @@ void tickEasyPlaceImpl() {
             }
         }
         // While the button stays held, pause for the initial delay and then
-        // repeat at a steady rate (typematic).
-        if (!allowed && placementState().manualHeld()
+        // repeat at a steady rate (typematic), so a held right-click keeps
+        // placing along the projection cells the crosshair sweeps over.
+        if (!allowed && placementState().manualHeld() && rightHeld
             && nowManual - placementState().manualPressAt() >= kManualInitialDelayMs
             && nowManual - placementState().lastManualPlaceAt() >= kManualRepeatIntervalMs) {
             allowed = true;
@@ -904,7 +929,7 @@ void tickEasyPlaceImpl() {
         placementState().setNextSwapAt(now + kSwapRetryMs);
         return;
     }
-    player->setSelectedSlot(found.slot);
+    { detail::ModSlotSelectGuard g; player->setSelectedSlot(found.slot); }
     if (!placeBlock(*player, placement, found.slot, *found.item)) return;
     markPlaced(placement.cell, now);
     // Manual repeat bookkeeping: record this placement and mark the current

--- a/src/place/PlacementExecutor.h
+++ b/src/place/PlacementExecutor.h
@@ -38,4 +38,20 @@ ManualTargetStatus manualTargetStatusUnderCrosshair();
 
 void tickRangePlace(LocalPlayer& player, PlacementContext const& context);
 
+// True while the mod itself is changing the held hotbar slot (its placement
+// item swap). The PlayerInventory::selectSlot hook consults this so it only
+// suppresses wheel-driven hotbar changes, never the mod's own slot swaps.
+bool modSlotSelectActive();
+
+// RAII marker set around the mod's own setSelectedSlot calls.
+struct ModSlotSelectGuard {
+    ModSlotSelectGuard();
+    ~ModSlotSelectGuard();
+    ModSlotSelectGuard(ModSlotSelectGuard const&)            = delete;
+    ModSlotSelectGuard& operator=(ModSlotSelectGuard const&) = delete;
+
+private:
+    bool mPrev;
+};
+
 } // namespace lholo::place::detail

--- a/src/settings/SettingsStore.cpp
+++ b/src/settings/SettingsStore.cpp
@@ -27,6 +27,8 @@ bool loadSettingsFile(std::filesystem::path const& path, Settings& out) {
     out.experimentalConsent = json.value("experimentalConsent", out.experimentalConsent);
     out.materialHudEnabled = json.value("materialHudEnabled", out.materialHudEnabled);
     out.materialHudPosition = json.value("materialHudPosition", out.materialHudPosition);
+    out.stickToolEnabled = json.value("stickToolEnabled", out.stickToolEnabled);
+    out.hudAlwaysVisible = json.value("hudAlwaysVisible", out.hudAlwaysVisible);
     out.placementRadius = json.value("placementRadius", out.placementRadius);
     out.autoPlacementBreakCooldownSeconds = json.value(
         "autoPlacementBreakCooldownSeconds",
@@ -59,6 +61,9 @@ bool loadSettingsFile(std::filesystem::path const& path, Settings& out) {
     out.closeProjectionHotkey = json.value("closeProjectionHotkey", out.closeProjectionHotkey);
     out.closeProjectionHotkeyModifiers
         = json.value("closeProjectionHotkeyModifiers", out.closeProjectionHotkeyModifiers);
+    out.scrollMoveHotkey = json.value("scrollMoveHotkey", out.scrollMoveHotkey);
+    out.scrollMoveHotkeyModifiers
+        = json.value("scrollMoveHotkeyModifiers", out.scrollMoveHotkeyModifiers);
 
     static char const* moveKeyNames[]{
         "moveXMinusHotkey",
@@ -116,6 +121,8 @@ void saveSettingsFile(std::filesystem::path const& path, Settings const& setting
         {"experimentalConsent", settings.experimentalConsent},
         {"materialHudEnabled", settings.materialHudEnabled},
         {"materialHudPosition", settings.materialHudPosition},
+        {"stickToolEnabled", settings.stickToolEnabled},
+        {"hudAlwaysVisible", settings.hudAlwaysVisible},
         {"placementRadius", settings.placementRadius},
         {"autoPlacementBreakCooldownSeconds", settings.autoPlacementBreakCooldownSeconds},
         {"hudEnabled", settings.hudEnabled},
@@ -138,6 +145,8 @@ void saveSettingsFile(std::filesystem::path const& path, Settings const& setting
         {"loadProjectionHotkeyModifiers", settings.loadProjectionHotkeyModifiers},
         {"closeProjectionHotkey", settings.closeProjectionHotkey},
         {"closeProjectionHotkeyModifiers", settings.closeProjectionHotkeyModifiers},
+        {"scrollMoveHotkey", settings.scrollMoveHotkey},
+        {"scrollMoveHotkeyModifiers", settings.scrollMoveHotkeyModifiers},
         {"moveXMinusHotkey", settings.moveHotkeys[0]},
         {"moveXPlusHotkey", settings.moveHotkeys[1]},
         {"moveZMinusHotkey", settings.moveHotkeys[2]},

--- a/src/settings/SettingsStore.h
+++ b/src/settings/SettingsStore.h
@@ -26,6 +26,8 @@ struct Settings {
     bool experimentalConsent{false};
     bool materialHudEnabled{false};
     int materialHudPosition{3};
+    bool stickToolEnabled{false};
+    bool hudAlwaysVisible{false};
     int placementRadius{4};
     int autoPlacementBreakCooldownSeconds{10};
     bool hudEnabled{true};
@@ -48,6 +50,9 @@ struct Settings {
     int loadProjectionHotkeyModifiers{0};
     int closeProjectionHotkey{0};
     int closeProjectionHotkeyModifiers{0};
+    // Held (not pressed) while scrolling to move the projection. Default Alt.
+    int scrollMoveHotkey{0};
+    int scrollMoveHotkeyModifiers{2}; // kHotkeyModifierAlt
     // X-, X+, Z-, Z+, Y+, Y-
     std::array<int, input::kMoveHotkeyCount> moveHotkeys{0x25, 0x27, 0x26, 0x28, 0x26, 0x28};
     std::array<int, input::kMoveHotkeyCount> moveHotkeyModifiers{1, 1, 1, 1, 4, 4};

--- a/src/structure/StructureLoader.cpp
+++ b/src/structure/StructureLoader.cpp
@@ -69,6 +69,7 @@ constexpr std::size_t kLayerIncreaseHotkeyIndex = input::hotkeyIndex(input::Hotk
 constexpr std::size_t kLayerDecreaseHotkeyIndex = input::hotkeyIndex(input::HotkeyId::LayerDecrease);
 constexpr std::size_t kLoadProjectionHotkeyIndex = input::hotkeyIndex(input::HotkeyId::LoadProjection);
 constexpr std::size_t kCloseProjectionHotkeyIndex = input::hotkeyIndex(input::HotkeyId::CloseProjection);
+constexpr std::size_t kScrollMoveHotkeyIndex = input::hotkeyIndex(input::HotkeyId::ScrollMove);
 constexpr float kActionHintVerticalScreenRatio = 0.80f;
 auto& logger() {
     return LHolo::getInstance().getSelf().getLogger();
@@ -387,6 +388,8 @@ void renderActionHint() {
 void renderHud() {
     if (isGuiVisible()) return;
     if (!hudContextAvailable()) return;
+    // Stick-tool mode hides the info HUD unless a stick is held (or it is pinned).
+    if (stickToolEnabled() && !hudAlwaysVisible() && !holdingStick()) return;
     auto const hud = uiState().hud();
     if (!hud.enabled) return;
     auto const showFileName = hud.showFileName;
@@ -515,6 +518,13 @@ void renderHud() {
         auto const aimedProjectedBlock = place::getAimedProjectedBlockName();
         if (showProjectedBlockName && !aimedProjectedBlock.empty()) {
             ImGui::Text("投影方块：%s", aimedProjectedBlock.c_str());
+        }
+        // Show which assisted-placement mode (if any) is currently on.
+        char const* const placeMode = place::isManualMode() ? "手动放置"
+            : place::isEnabled() ? "轻松放置"
+            : place::isRangeEnabled() ? "范围放置" : nullptr;
+        if (placeMode) {
+            ImGui::TextColored(ImVec4(0.45f, 0.85f, 1.0f, 1.0f), "辅助放置：%s", placeMode);
         }
         // Record our rect + corner so the material HUD (drawn right after) can
         // stack clear of us when it shares this corner, instead of overlapping.
@@ -649,6 +659,8 @@ void loadSettings() {
         projection::setMissingSeeThrough(settings.missingSeeThrough);
         setExperimentalConsentGiven(settings.experimentalConsent);
         setMaterialHudEnabled(settings.materialHudEnabled);
+        setStickToolEnabled(settings.stickToolEnabled);
+        setHudAlwaysVisible(settings.hudAlwaysVisible);
         setMaterialHudPosition(settings.materialHudPosition);
         // Transform and layer state are session-local. Only the explicit
         // "restore last projection" record below is persisted.
@@ -706,6 +718,11 @@ void loadSettings() {
             std::clamp(settings.closeProjectionHotkey, 0, 255),
             std::clamp(settings.closeProjectionHotkeyModifiers, 0, 7)
         );
+        uiState().setHotkey(
+            kScrollMoveHotkeyIndex,
+            std::clamp(settings.scrollMoveHotkey, 0, 255),
+            std::clamp(settings.scrollMoveHotkeyModifiers, 0, 7)
+        );
         session.setSavedProjection({
             settings.hasSavedProjection,
             settings.savedAnchorX,
@@ -751,6 +768,8 @@ void saveSettings() {
         settings.missingSeeThrough = projection::getMissingSeeThrough();
         settings.experimentalConsent = experimentalConsentGiven();
         settings.materialHudEnabled = materialHudEnabled();
+        settings.stickToolEnabled = stickToolEnabled();
+        settings.hudAlwaysVisible = hudAlwaysVisible();
         settings.materialHudPosition = materialHudPosition();
         settings.placementRadius = place::getPlacementRadius();
         settings.autoPlacementBreakCooldownSeconds
@@ -785,6 +804,9 @@ void saveSettings() {
         settings.loadProjectionHotkeyModifiers = loadProjectionHotkey.modifiers;
         settings.closeProjectionHotkey = closeProjectionHotkey.key;
         settings.closeProjectionHotkeyModifiers = closeProjectionHotkey.modifiers;
+        auto const scrollMoveHotkey = uiState().hotkey(kScrollMoveHotkeyIndex);
+        settings.scrollMoveHotkey = scrollMoveHotkey.key;
+        settings.scrollMoveHotkeyModifiers = scrollMoveHotkey.modifiers;
         settings.hasSavedProjection = sessionSnapshot.saved.available;
         settings.savedAnchorX = sessionSnapshot.saved.anchorX;
         settings.savedAnchorY = sessionSnapshot.saved.anchorY;
@@ -826,6 +848,56 @@ int getLayerAxis() { return detail::StructureSession::getInstance().transform().
 void recordProjectionAnchor(int x, int y, int z) {
     detail::StructureSession::getInstance().recordProjectionAnchor(x, y, z);
     saveSettings();
+}
+
+namespace {
+std::atomic_int  gPendingFacingScroll{0};
+// "Stick tool" mode (JE-style): when on, the Alt+wheel projection nudge only
+// works while holding a stick, and the info HUD shows only while holding one
+// (unless it is pinned always-on). gHoldingStick is refreshed each tick.
+std::atomic_bool gStickToolEnabled{false};
+std::atomic_bool gHudAlwaysVisible{false};
+std::atomic_bool gHoldingStick{false};
+}
+
+bool stickToolEnabled() { return gStickToolEnabled.load(std::memory_order_acquire); }
+void setStickToolEnabled(bool enabled) {
+    gStickToolEnabled.store(enabled, std::memory_order_release);
+}
+bool hudAlwaysVisible() { return gHudAlwaysVisible.load(std::memory_order_acquire); }
+void setHudAlwaysVisible(bool enabled) {
+    gHudAlwaysVisible.store(enabled, std::memory_order_release);
+}
+bool holdingStick() { return gHoldingStick.load(std::memory_order_acquire); }
+void setHoldingStick(bool holding) {
+    gHoldingStick.store(holding, std::memory_order_release);
+}
+
+bool scrollLockActive() {
+    if (!getLoaded()) return false;  // nothing to move; let the wheel scroll the hotbar
+    if (stickToolEnabled() && !holdingStick()) return false;  // needs a stick in hand
+    return true;
+}
+
+bool scrollModifierHeld() { return uiState().scrollModifierHeld(); }
+
+bool queueFacingScroll(int notches) {
+    if (!scrollLockActive()) return false;
+    gPendingFacingScroll.fetch_add(notches, std::memory_order_acq_rel);
+    return true;
+}
+
+void applyFacingScroll(float viewX, float viewY, float viewZ) {
+    int const notches = gPendingFacingScroll.exchange(0, std::memory_order_acq_rel);
+    if (notches == 0) return;
+    // Move along the dominant look axis, in the direction the player faces:
+    // scroll forward (notches > 0) pushes the projection away along that axis.
+    float const ax = std::abs(viewX), ay = std::abs(viewY), az = std::abs(viewZ);
+    int dx = 0, dy = 0, dz = 0;
+    if (ax >= ay && ax >= az)  dx = (viewX >= 0.0f ? 1 : -1) * notches;
+    else if (ay >= az)         dy = (viewY >= 0.0f ? 1 : -1) * notches;
+    else                       dz = (viewZ >= 0.0f ? 1 : -1) * notches;
+    detail::StructureSession::getInstance().adjustOffsets(dx, dy, dz);
 }
 
 void restoreSavedProjection() {

--- a/src/structure/StructureLoader.h
+++ b/src/structure/StructureLoader.h
@@ -116,6 +116,29 @@ int getLayerDisplayMode();
 int getDisplayLayer();
 int getLayerAxis();
 void recordProjectionAnchor(int x, int y, int z);
+// Alt + wheel projection nudge. queueFacingScroll accumulates wheel notches from
+// the input thread (returns false, so the wheel is not consumed, when no
+// projection is loaded); applyFacingScroll runs on the tick thread with the
+// player's look vector and shifts the offset along the dominant facing axis.
+bool queueFacingScroll(int notches);
+void applyFacingScroll(float viewX, float viewY, float viewZ);
+// True when Alt+wheel should capture the wheel: a projection is loaded and, in
+// stick-tool mode, a stick is in hand. The selectSlot hook uses this to decide
+// whether to lock the hotbar, so the hotbar lock and the projection move engage
+// under exactly the same condition.
+bool scrollLockActive();
+// True while the ScrollMove hotkey (default Alt) is physically held. Used by the
+// wheel handler and the selectSlot hook so the trigger key is rebindable.
+bool scrollModifierHeld();
+// "Stick tool" mode: use a stick to move the projection (Alt+wheel), and gate the
+// info HUD on holding a stick unless pinned always-visible.
+bool stickToolEnabled();
+void setStickToolEnabled(bool enabled);
+bool hudAlwaysVisible();
+void setHudAlwaysVisible(bool enabled);
+// Runtime flag: whether the player currently holds a stick (refreshed each tick).
+bool holdingStick();
+void setHoldingStick(bool holding);
 void clear();
 // Reload the last saved projection at its saved anchor/transform. Standalone so
 // both the menu action and the load hotkey can trigger it.

--- a/src/structure/StructureUiState.cpp
+++ b/src/structure/StructureUiState.cpp
@@ -37,6 +37,7 @@ constexpr std::array<DefaultHotkey, input::kHotkeyCount> kDefaultHotkeys{{
     {VK_DOWN, lholo::ui::kHotkeyModifierAlt},
     {0,       0},
     {0,       0},
+    {0,       lholo::ui::kHotkeyModifierAlt},  // ScrollMove: hold Alt + wheel
 }};
 
 } // namespace
@@ -153,6 +154,17 @@ HotkeyBindingSnapshot StructureUiState::inputHotkey(std::size_t index) const {
         storage->modifiers.load(std::memory_order_acquire),
         storage->capturing.load(std::memory_order_acquire)
     };
+}
+
+bool StructureUiState::scrollModifierHeld() const {
+    auto const snapshot = inputHotkey(input::hotkeyIndex(input::HotkeyId::ScrollMove));
+    if (snapshot.key == 0 && snapshot.modifiers == 0) return false;  // unbound
+    auto const down = [](int vkey) { return (GetAsyncKeyState(vkey) & 0x8000) != 0; };
+    if (snapshot.key != 0 && !down(static_cast<int>(snapshot.key))) return false;
+    if ((snapshot.modifiers & lholo::ui::kHotkeyModifierControl) && !down(VK_CONTROL)) return false;
+    if ((snapshot.modifiers & lholo::ui::kHotkeyModifierAlt) && !down(VK_MENU)) return false;
+    if ((snapshot.modifiers & lholo::ui::kHotkeyModifierShift) && !down(VK_SHIFT)) return false;
+    return true;
 }
 
 void StructureUiState::setHotkey(

--- a/src/structure/StructureUiState.h
+++ b/src/structure/StructureUiState.h
@@ -115,6 +115,9 @@ public:
     void setAltHeld(bool held);
     void setShiftHeld(bool held);
     [[nodiscard]] unsigned int currentHotkeyModifiers() const;
+    // True when the ScrollMove hotkey's binding (key and/or modifiers) is
+    // physically held right now. Safe to poll from the input thread.
+    [[nodiscard]] bool scrollModifierHeld() const;
     [[nodiscard]] bool tryPressHotkey(std::size_t index);
     [[nodiscard]] bool releaseHotkeysForKey(unsigned int key, std::uint64_t now);
     void resetHotkeyState();

--- a/src/ui/HotkeyFormat.cpp
+++ b/src/ui/HotkeyFormat.cpp
@@ -69,11 +69,17 @@ std::string hotkeyName(unsigned int key) {
 }
 
 std::string hotkeyChordName(unsigned int modifiers, unsigned int key) {
-    if (key == 0) return "未设置";
     std::string result;
     if ((modifiers & kHotkeyModifierControl) != 0) result += "Ctrl + ";
     if ((modifiers & kHotkeyModifierAlt) != 0) result += "Alt + ";
     if ((modifiers & kHotkeyModifierShift) != 0) result += "Shift + ";
+    if (key == 0) {
+        // A modifier-only binding (e.g. the default Alt for projection scroll)
+        // has no main key; show just the modifier(s) instead of "未设置".
+        if (result.empty()) return "未设置";
+        result.erase(result.size() - 3);  // drop the trailing " + "
+        return result;
+    }
     result += hotkeyName(key);
     return result;
 }

--- a/src/ui/LHoloMenu.h
+++ b/src/ui/LHoloMenu.h
@@ -116,6 +116,8 @@ struct MenuModel {
     bool materialPopupRequested{};
     bool materialHudEnabled{};
     int  materialHudPosition{3};
+    bool stickToolEnabled{};
+    bool hudAlwaysVisible{};
     bool closeRequested{};
 };
 

--- a/src/ui/MenuController.cpp
+++ b/src/ui/MenuController.cpp
@@ -61,7 +61,8 @@ constexpr std::array<HotkeyDefinition, input::kHotkeyCount> kHotkeyDefinitions{{
     {HotkeyId::LayerIncrease, "上一层"},
     {HotkeyId::LayerDecrease, "下一层"},
     {HotkeyId::LoadProjection, "加载投影"},
-    {HotkeyId::CloseProjection, "关闭投影"}
+    {HotkeyId::CloseProjection, "关闭投影"},
+    {HotkeyId::ScrollMove, "移动投影修饰键（滚轮）"}
 }};
 
 } // namespace
@@ -108,6 +109,8 @@ MenuModel buildStructureMenuModel(float effectiveUiScale) {
     model.experimentalConsent = structure::experimentalConsentGiven();
     model.materialHudEnabled = structure::materialHudEnabled();
     model.materialHudPosition = std::clamp(structure::materialHudPosition(), 0, 3);
+    model.stickToolEnabled = structure::stickToolEnabled();
+    model.hudAlwaysVisible = structure::hudAlwaysVisible();
     model.placementRadius = place::getPlacementRadius();
     model.autoPlacementBreakCooldownSeconds = place::getAutoPlacementBreakCooldownSeconds();
     model.offsetX = sessionSnapshot.transform.offsetX;
@@ -233,6 +236,14 @@ void applyStructureMenuModel(MenuModel const& model, float effectiveUiScale) {
     auto const materialPosition = std::clamp(model.materialHudPosition, 0, 3);
     if (structure::materialHudPosition() != materialPosition) {
         structure::setMaterialHudPosition(materialPosition);
+        changed = true;
+    }
+    if (structure::stickToolEnabled() != model.stickToolEnabled) {
+        structure::setStickToolEnabled(model.stickToolEnabled);
+        changed = true;
+    }
+    if (structure::hudAlwaysVisible() != model.hudAlwaysVisible) {
+        structure::setHudAlwaysVisible(model.hudAlwaysVisible);
         changed = true;
     }
     structure::capture::Draft captureDraft;

--- a/src/ui/MenuPages.cpp
+++ b/src/ui/MenuPages.cpp
@@ -544,6 +544,17 @@ void renderHotkeysPage(MenuModel& model, MenuActions const& actions, UiMetrics c
         ImGui::PopStyleVar();
         if (ImGui::Button("恢复默认快捷键") && actions.resetHotkeys) actions.resetHotkeys();
         ImGui::TextDisabled("可在聊天栏输入 LHolo 打开投影菜单");
+        ImGui::Separator();
+        renderCheckboxRow(
+            "##StickTool", "使用木棒操作投影（持木棒才可用修饰键+滚轮移动，信息 HUD 仅持木棒时显示）",
+            model.stickToolEnabled, metrics
+        );
+        ImGui::BeginDisabled(!model.stickToolEnabled);
+        renderCheckboxRow(
+            "##HudAlwaysVisible", "信息 HUD 常驻显示（不需手持木棒）",
+            model.hudAlwaysVisible, metrics
+        );
+        ImGui::EndDisabled();
     });
 }
 


### PR DESCRIPTION
- Move the projection with a scroll modifier (default Alt, rebindable on the Hotkeys page) along the axis the player faces, JE-style. The hotbar is kept from scrolling by hooking PlayerInventory::selectSlot while the modifier is held, because Bedrock reads the gameplay wheel through its own input pipeline rather than the window proc, so consuming the window message cannot stop it. The mod's own placement slot swaps are exempt.
- Optional "stick tool" mode: the Alt+wheel move and the info HUD apply only while holding a stick, with an always-on HUD option. Both toggles live on the Hotkeys page.
- Show the active assisted-placement mode (manual/easy/range) on the HUD.
- Manual placement keeps placing while the right mouse button is held.